### PR TITLE
feat: add location interface

### DIFF
--- a/interfaces/interface_variable.go
+++ b/interfaces/interface_variable.go
@@ -259,15 +259,3 @@ func CheckWithReturnValue[TR any](c Checker, check func() (TR, bool, error)) (re
 		err:           err,
 	}
 }
-
-func CheckBool(c Checker, check func() (bool, error)) (rc Checker) {
-	if c.err != nil || !c.continueCheck {
-		rc = c
-		return
-	}
-	continueCheck, err := check()
-	return Checker{
-		continueCheck: continueCheck,
-		err:           err,
-	}
-}

--- a/interfaces/interfaces.go
+++ b/interfaces/interfaces.go
@@ -8,6 +8,7 @@ import (
 var Rules = []tflint.Rule{
 	NewVarCheckRuleFromAvmInterface(CustomerManagedKey),
 	NewVarCheckRuleFromAvmInterface(DiagnosticSettings),
+	NewVarCheckRuleFromAvmInterface(Location),
 	NewVarCheckRuleFromAvmInterface(Lock),
 	NewVarCheckRuleFromAvmInterface(ManagedIdentities),
 	NewVarCheckRuleFromAvmInterface(RoleAssignments),

--- a/interfaces/interfaces_simple_test.go
+++ b/interfaces/interfaces_simple_test.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/Azure/tflint-ruleset-avm/interfaces"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/matt-FFFFFF/tfvarcheck/varcheck"
+	"github.com/stretchr/testify/assert"
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/zclconf/go-cty/cty"

--- a/interfaces/interfaces_simple_test.go
+++ b/interfaces/interfaces_simple_test.go
@@ -2,8 +2,9 @@ package interfaces_test
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/Azure/tflint-ruleset-avm/interfaces"
 	"github.com/hashicorp/hcl/v2"
@@ -30,6 +31,16 @@ var SimpleVar = interfaces.AvmInterface{
 	RuleSeverity:  tflint.ERROR,
 }
 
+// SimpleVar represents a simple variable type with no default value used for testing.
+var SimpleVarNoDefault = interfaces.AvmInterface{
+	VarCheck:      varcheck.NewVarCheck(simpleType, cty.UnknownVal(cty.DynamicPseudoType), false),
+	RuleName:      "simple",
+	VarTypeString: simpleVarTypeString,
+	RuleEnabled:   true,
+	RuleLink:      "https://simple",
+	RuleSeverity:  tflint.ERROR,
+}
+
 func TestIncorrectInterfaceTypeStringShouldPanic(t *testing.T) {
 	defer func() {
 		err := recover()
@@ -38,6 +49,76 @@ func TestIncorrectInterfaceTypeStringShouldPanic(t *testing.T) {
 	incorrectTypeString := `strin`
 	interfaces.StringToTypeConstraintWithDefaults(incorrectTypeString)
 	t.Fatal("incorrect type should panic")
+}
+
+func TestSimpleInterfaceNoDefault(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		JSON     bool
+		Expected helper.Issues
+	}{
+		{
+			Name:     "correct",
+			Content:  toTerraformVarType(SimpleVarNoDefault),
+			Expected: helper.Issues{},
+		},
+
+		{
+			Name: "incorrect - has default value",
+			Content: `
+variable "simple" {
+	type = object({
+		kind = string
+		name = optional(string, null)
+	})
+	default = {}
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    interfaces.NewVarCheckRuleFromAvmInterface(SimpleVarNoDefault),
+					Message: "`simple` default should not be declared",
+				},
+			},
+		},
+		{
+			Name: "incorrect - is nullable",
+			Content: `
+variable "simple" {
+	type = object({
+		kind = string
+		name = optional(string, null)
+	})
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    interfaces.NewVarCheckRuleFromAvmInterface(SimpleVarNoDefault),
+					Message: "nullable should be set to false",
+				},
+			},
+		},
+	}
+
+	rule := interfaces.NewVarCheckRuleFromAvmInterface(SimpleVarNoDefault)
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			filename := "variables.tf"
+			if tc.JSON {
+				filename += ".json"
+			}
+
+			runner := helper.TestRunner(t, map[string]string{filename: tc.Content})
+
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			helper.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
+		})
+	}
 }
 
 func TestSimpleInterface(t *testing.T) {

--- a/interfaces/interfaces_test.go
+++ b/interfaces/interfaces_test.go
@@ -20,7 +20,9 @@ func toTerraformVarType(i interfaces.AvmInterface) string {
 			SpacesBefore: 1,
 		},
 	})
-	varBody.SetAttributeValue("default", i.Default)
+	if i.Default.IsKnown() {
+		varBody.SetAttributeValue("default", i.Default)
+	}
 	if !i.Nullable {
 		varBody.SetAttributeValue("nullable", cty.False)
 	}

--- a/interfaces/location.go
+++ b/interfaces/location.go
@@ -1,0 +1,20 @@
+package interfaces
+
+import (
+	"github.com/matt-FFFFFF/tfvarcheck/varcheck"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/zclconf/go-cty/cty"
+)
+
+var LocationTypeString = `string`
+
+var locationType = StringToTypeConstraintWithDefaults(LocationTypeString)
+
+var Location = AvmInterface{
+	VarCheck:      varcheck.NewVarCheck(locationType, cty.UnknownVal(cty.String), false),
+	RuleName:      "location",
+	VarTypeString: LocationTypeString,
+	RuleEnabled:   true,
+	RuleLink:      "https://azure.github.io/Azure-Verified-Modules/specs/shared/interfaces/#resource-locks",
+	RuleSeverity:  tflint.ERROR,
+}

--- a/interfaces/location.go
+++ b/interfaces/location.go
@@ -15,6 +15,6 @@ var Location = AvmInterface{
 	RuleName:      "location",
 	VarTypeString: LocationTypeString,
 	RuleEnabled:   true,
-	RuleLink:      "https://azure.github.io/Azure-Verified-Modules/specs/shared/interfaces/#resource-locks",
+	RuleLink:      "https://azure.github.io/Azure-Verified-Modules/specs/shared/#id-rmnfr2---category-inputs---parametervariable-naming",
 	RuleSeverity:  tflint.ERROR,
 }

--- a/interfaces/location_test.go
+++ b/interfaces/location_test.go
@@ -1,0 +1,45 @@
+package interfaces_test
+
+import (
+	"testing"
+
+	"github.com/Azure/tflint-ruleset-avm/interfaces"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+// TestLockTerraformVar tests Lock interface.
+func TestTerraformLocationInterface(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		JSON     bool
+		Expected helper.Issues
+	}{
+		{
+			Name:     "correct",
+			Content:  toTerraformVarType(interfaces.Location),
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := interfaces.NewVarCheckRuleFromAvmInterface(interfaces.Location)
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			filename := "variables.tf"
+			if tc.JSON {
+				filename += ".json"
+			}
+
+			runner := helper.TestRunner(t, map[string]string{filename: tc.Content})
+
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			helper.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds in an interface for the locaiton variable, which should be mandatory (have no default).

This necessated chanegs to the check logic to handle the case where the attribute did not exist in the block.