### PR TITLE
Add missing rules and make names nicer

### DIFF
--- a/attrvalue/nested_block_value_test.go
+++ b/attrvalue/nested_block_value_test.go
@@ -21,7 +21,7 @@ func TestNestedBlockValueRule(t *testing.T) {
 	}{
 		{
 			name: "correct string",
-			rule: attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", false),
+			rule: attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", false, ""),
 			content: `
 	variable "test" {
 		type    = string
@@ -36,7 +36,7 @@ func TestNestedBlockValueRule(t *testing.T) {
 		},
 		{
 			name: "incorrect string",
-			rule: attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", false),
+			rule: attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", false, ""),
 			content: `
 	variable "test" {
 		type    = string
@@ -49,14 +49,14 @@ func TestNestedBlockValueRule(t *testing.T) {
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", false),
+					Rule:    attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", false, ""),
 					Message: "baz is an invalid attribute value of `bar` - expecting (one of) [biz bat]",
 				},
 			},
 		},
 		{
 			name: "incorrect resource with correct block",
-			rule: attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", false),
+			rule: attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", false, ""),
 			content: `
 	variable "test" {
 		type    = string
@@ -71,7 +71,7 @@ func TestNestedBlockValueRule(t *testing.T) {
 		},
 		{
 			name: "no nested block of that type",
-			rule: attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", false),
+			rule: attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", false, ""),
 			content: `
 	variable "test" {
 		type    = string
@@ -86,7 +86,7 @@ func TestNestedBlockValueRule(t *testing.T) {
 		},
 		{
 			name: "no nested block of that type with must exist set",
-			rule: attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", true),
+			rule: attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", true, ""),
 			content: `
 	variable "test" {
 		type    = string
@@ -99,14 +99,14 @@ func TestNestedBlockValueRule(t *testing.T) {
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", true),
+					Rule:    attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", true, ""),
 					Message: "The attribute `bar` must be specified",
 				},
 			},
 		},
 		{
 			name: "no nested block attribute of that type with must exist set",
-			rule: attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", true),
+			rule: attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", true, ""),
 			content: `
 	variable "test" {
 		type    = string
@@ -119,14 +119,14 @@ func TestNestedBlockValueRule(t *testing.T) {
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", true),
+					Rule:    attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", true, ""),
 					Message: "The attribute `bar` must be specified",
 				},
 			},
 		},
 		{
 			name: "multiple blocks correct",
-			rule: attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", false),
+			rule: attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", false, ""),
 			content: `
 	variable "test" {
 		type    = string
@@ -144,7 +144,7 @@ func TestNestedBlockValueRule(t *testing.T) {
 		},
 		{
 			name: "multiple blocks partially correct",
-			rule: attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", false),
+			rule: attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", false, ""),
 			content: `
 	variable "test" {
 		type    = string
@@ -164,7 +164,7 @@ func TestNestedBlockValueRule(t *testing.T) {
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", false),
+					Rule:    attrvalue.NewSimpleNestedBlockRule("foo", "fiz", "bar", []string{"biz", "bat"}, "", false, ""),
 					Message: "incorrect is an invalid attribute value of `bar` - expecting (one of) [biz bat]",
 				},
 			},

--- a/attrvalue/set_value.go
+++ b/attrvalue/set_value.go
@@ -16,24 +16,30 @@ type SetRule[T cmp.Ordered] struct {
 	tflint.DefaultRule // Embed the default rule to reuse its implementation
 	baseValue
 	expectedValues [][]T // e.g. [][int{1, 2, 3}]
+	ruleName	   string
 }
 
 var _ tflint.Rule = (*SetRule[int])(nil)
 var _ AttrValueRule = (*SimpleRule[any])(nil)
 
 // NewSetRule returns a new rule with the given resource type, attribute name, and expected values.
-func NewSetRule[T cmp.Ordered](resourceType string, attributeName string, expectedValues [][]T, link string) *SetRule[T] {
+func NewSetRule[T cmp.Ordered](resourceType string, attributeName string, expectedValues [][]T, link string, ruleName string) *SetRule[T] {
 	return &SetRule[T]{
 		baseValue:      newBaseValue(resourceType, nil, attributeName, true, link, tflint.ERROR),
 		expectedValues: expectedValues,
+		ruleName: 	    ruleName,
 	}
 }
 
 func (r *SetRule[T]) Name() string {
-	if r.nestedBlockType != nil {
-		return fmt.Sprintf("set_value_%s.%s.%s", r.resourceType, *r.nestedBlockType, r.attributeName)
+	if r.ruleName != "" {
+		return r.ruleName
 	}
-	return fmt.Sprintf("set_value_%s.%s", r.resourceType, r.attributeName)
+
+	if r.nestedBlockType != nil {
+		return fmt.Sprintf("%s.%s.%s", r.resourceType, *r.nestedBlockType, r.attributeName)
+	}
+	return fmt.Sprintf("%s.%s", r.resourceType, r.attributeName)
 }
 
 func (r *SetRule[T]) Check(runner tflint.Runner) error {

--- a/attrvalue/set_value.go
+++ b/attrvalue/set_value.go
@@ -16,7 +16,7 @@ type SetRule[T cmp.Ordered] struct {
 	tflint.DefaultRule // Embed the default rule to reuse its implementation
 	baseValue
 	expectedValues [][]T // e.g. [][int{1, 2, 3}]
-	ruleName	   string
+	ruleName       string
 }
 
 var _ tflint.Rule = (*SetRule[int])(nil)
@@ -27,7 +27,7 @@ func NewSetRule[T cmp.Ordered](resourceType string, attributeName string, expect
 	return &SetRule[T]{
 		baseValue:      newBaseValue(resourceType, nil, attributeName, true, link, tflint.ERROR),
 		expectedValues: expectedValues,
-		ruleName: 	    ruleName,
+		ruleName:       ruleName,
 	}
 }
 

--- a/attrvalue/set_value_test.go
+++ b/attrvalue/set_value_test.go
@@ -19,7 +19,7 @@ func TestListNumberValueRule(t *testing.T) {
 	}{
 		{
 			name: "incorrect",
-			rule: attrvalue.NewSetRule("foo", "bar", [][]int{{1, 2, 3}}, ""),
+			rule: attrvalue.NewSetRule("foo", "bar", [][]int{{1, 2, 3}}, "", ""),
 			content: `
 	variable "test" {
 		type    = list(number)
@@ -30,14 +30,14 @@ func TestListNumberValueRule(t *testing.T) {
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    attrvalue.NewSetRule("foo", "bar", [][]int{{1, 2, 3}}, ""),
+					Rule:    attrvalue.NewSetRule("foo", "bar", [][]int{{1, 2, 3}}, "", ""),
 					Message: "\"[3]\" is an invalid attribute value of `bar` - expecting (one of) [[1 2 3]]",
 				},
 			},
 		},
 		{
 			name: "correct",
-			rule: attrvalue.NewSetRule("foo", "bar", [][]int{{1, 2, 3}}, ""),
+			rule: attrvalue.NewSetRule("foo", "bar", [][]int{{1, 2, 3}}, "", ""),
 			content: `
 	variable "test" {
 		type    = list(number)
@@ -50,7 +50,7 @@ func TestListNumberValueRule(t *testing.T) {
 		},
 		{
 			name: "correct with string list",
-			rule: attrvalue.NewSetRule("foo", "bar", [][]string{{"1", "2", "3"}}, ""),
+			rule: attrvalue.NewSetRule("foo", "bar", [][]string{{"1", "2", "3"}}, "", ""),
 			content: `
 	variable "test" {
 		type    = list(string)
@@ -63,7 +63,7 @@ func TestListNumberValueRule(t *testing.T) {
 		},
 		{
 			name: "correct but different order",
-			rule: attrvalue.NewSetRule("foo", "bar", [][]int{{1, 2, 3}}, ""),
+			rule: attrvalue.NewSetRule("foo", "bar", [][]int{{1, 2, 3}}, "", ""),
 			content: `
 	variable "test" {
 		type    = list(number)
@@ -76,7 +76,7 @@ func TestListNumberValueRule(t *testing.T) {
 		},
 		{
 			name: "variable without default",
-			rule: attrvalue.NewSetRule("foo", "bar", [][]int{{1, 2, 3}}, ""),
+			rule: attrvalue.NewSetRule("foo", "bar", [][]int{{1, 2, 3}}, "", ""),
 			content: `
 		variable "test" {
 			type    = list(number)
@@ -88,7 +88,7 @@ func TestListNumberValueRule(t *testing.T) {
 		},
 		{
 			name: "variable with convertable element type",
-			rule: attrvalue.NewSetRule("foo", "bar", [][]int{{1, 2, 3}}, ""),
+			rule: attrvalue.NewSetRule("foo", "bar", [][]int{{1, 2, 3}}, "", ""),
 			content: `
 	variable "test" {
 		type    = list(string)

--- a/attrvalue/simple_value.go
+++ b/attrvalue/simple_value.go
@@ -17,26 +17,29 @@ type SimpleRule[T any] struct {
 	baseValue
 	expectedValues []T // e.g. []string{"ZRS"}
 	mustExist      bool
+	ruleName       string
 }
 
 var _ tflint.Rule = (*SimpleRule[any])(nil)
 var _ AttrValueRule = (*SimpleRule[any])(nil)
 
 // NewSimpleRule returns a new rule with the given resource type, attribute name, and expected values.
-func NewSimpleRule[T any](resourceType, attributeName string, expectedValues []T, link string, mustExist bool) *SimpleRule[T] {
+func NewSimpleRule[T any](resourceType, attributeName string, expectedValues []T, link string, mustExist bool, ruleName string) *SimpleRule[T] {
 	return &SimpleRule[T]{
 		baseValue:      newBaseValue(resourceType, nil, attributeName, true, link, tflint.ERROR),
 		expectedValues: expectedValues,
 		mustExist:      mustExist,
+		ruleName: 	    ruleName,
 	}
 }
 
 // NewSimpleNestedBlockRule returns a new rule with the given resource type, attribute name, and expected values.
-func NewSimpleNestedBlockRule[T any](resourceType, nestedBlockType, attributeName string, expectedValues []T, link string, mustExist bool) *SimpleRule[T] {
+func NewSimpleNestedBlockRule[T any](resourceType, nestedBlockType, attributeName string, expectedValues []T, link string, mustExist bool, ruleName string) *SimpleRule[T] {
 	return &SimpleRule[T]{
 		baseValue:      newBaseValue(resourceType, &nestedBlockType, attributeName, true, link, tflint.ERROR),
 		expectedValues: expectedValues,
 		mustExist:      mustExist,
+		ruleName: 	    ruleName,
 	}
 }
 
@@ -45,10 +48,14 @@ func (r *SimpleRule[T]) Link() string {
 }
 
 func (r *SimpleRule[T]) Name() string {
-	if r.nestedBlockType != nil {
-		return fmt.Sprintf("simple_value_%s.%s.%s", r.resourceType, *r.nestedBlockType, r.attributeName)
+	if r.ruleName != "" {
+		return r.ruleName
 	}
-	return fmt.Sprintf("simple_value_%s.%s", r.resourceType, r.attributeName)
+
+	if r.nestedBlockType != nil {
+		return fmt.Sprintf("%s.%s.%s", r.resourceType, *r.nestedBlockType, r.attributeName)
+	}
+	return fmt.Sprintf("%s.%s", r.resourceType, r.attributeName)
 }
 
 func (r *SimpleRule[T]) Check(runner tflint.Runner) error {

--- a/attrvalue/simple_value.go
+++ b/attrvalue/simple_value.go
@@ -29,7 +29,7 @@ func NewSimpleRule[T any](resourceType, attributeName string, expectedValues []T
 		baseValue:      newBaseValue(resourceType, nil, attributeName, true, link, tflint.ERROR),
 		expectedValues: expectedValues,
 		mustExist:      mustExist,
-		ruleName: 	    ruleName,
+		ruleName:       ruleName,
 	}
 }
 
@@ -39,7 +39,7 @@ func NewSimpleNestedBlockRule[T any](resourceType, nestedBlockType, attributeNam
 		baseValue:      newBaseValue(resourceType, &nestedBlockType, attributeName, true, link, tflint.ERROR),
 		expectedValues: expectedValues,
 		mustExist:      mustExist,
-		ruleName: 	    ruleName,
+		ruleName:       ruleName,
 	}
 }
 

--- a/attrvalue/simple_value_test.go
+++ b/attrvalue/simple_value_test.go
@@ -19,7 +19,7 @@ func TestSimpleValueRule(t *testing.T) {
 	}{
 		{
 			name: "correct string",
-			rule: attrvalue.NewSimpleRule("foo", "bar", []string{"bar", "bat"}, "", false),
+			rule: attrvalue.NewSimpleRule("foo", "bar", []string{"bar", "bat"}, "", false, ""),
 			content: `
 	variable "test" {
 		type    = string
@@ -32,7 +32,7 @@ func TestSimpleValueRule(t *testing.T) {
 		},
 		{
 			name: "incorrect string",
-			rule: attrvalue.NewSimpleRule("foo", "bar", []string{"bar", "bat"}, "", false),
+			rule: attrvalue.NewSimpleRule("foo", "bar", []string{"bar", "bat"}, "", false, ""),
 			content: `
 	variable "test" {
 		type    = string
@@ -43,14 +43,14 @@ func TestSimpleValueRule(t *testing.T) {
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    attrvalue.NewSimpleRule("foo", "bar", []string{"bar", "bat"}, "", false),
+					Rule:    attrvalue.NewSimpleRule("foo", "bar", []string{"bar", "bat"}, "", false, ""),
 					Message: "fiz is an invalid attribute value of `bar` - expecting (one of) [bar bat]",
 				},
 			},
 		},
 		{
 			name: "correct number",
-			rule: attrvalue.NewSimpleRule("foo", "bar", []int{1, 2}, "", false),
+			rule: attrvalue.NewSimpleRule("foo", "bar", []int{1, 2}, "", false, ""),
 			content: `
 	variable "test" {
 		type    = number
@@ -63,7 +63,7 @@ func TestSimpleValueRule(t *testing.T) {
 		},
 		{
 			name: "correct number float",
-			rule: attrvalue.NewSimpleRule("foo", "bar", []float64{1.2, 2.1}, "", false),
+			rule: attrvalue.NewSimpleRule("foo", "bar", []float64{1.2, 2.1}, "", false, ""),
 			content: `
 variable "test" {
 	type    = number
@@ -76,7 +76,7 @@ resource "foo" "example" {
 		},
 		{
 			name: "incorrect number",
-			rule: attrvalue.NewSimpleRule("foo", "bar", []int{1, 2}, "", false),
+			rule: attrvalue.NewSimpleRule("foo", "bar", []int{1, 2}, "", false, ""),
 			content: `
 	variable "test" {
 		type    = number
@@ -87,14 +87,14 @@ resource "foo" "example" {
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    attrvalue.NewSimpleRule("foo", "bar", []int{1, 2}, "", false),
+					Rule:    attrvalue.NewSimpleRule("foo", "bar", []int{1, 2}, "", false, ""),
 					Message: "3 is an invalid attribute value of `bar` - expecting (one of) [1 2]",
 				},
 			},
 		},
 		{
 			name: "incorrect number float",
-			rule: attrvalue.NewSimpleRule("foo", "bar", []float64{1.1, 2.2}, "", false),
+			rule: attrvalue.NewSimpleRule("foo", "bar", []float64{1.1, 2.2}, "", false, ""),
 			content: `
 	variable "test" {
 		type    = number
@@ -105,14 +105,14 @@ resource "foo" "example" {
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    attrvalue.NewSimpleRule("foo", "bar", []float64{1.1, 2.2}, "", false),
+					Rule:    attrvalue.NewSimpleRule("foo", "bar", []float64{1.1, 2.2}, "", false, ""),
 					Message: "2.1 is an invalid attribute value of `bar` - expecting (one of) [1.1 2.2]",
 				},
 			},
 		},
 		{
 			name: "correct bool",
-			rule: attrvalue.NewSimpleRule("foo", "bar", []bool{true}, "", false),
+			rule: attrvalue.NewSimpleRule("foo", "bar", []bool{true}, "", false, ""),
 			content: `
 	variable "test" {
 		type    = bool
@@ -125,7 +125,7 @@ resource "foo" "example" {
 		},
 		{
 			name: "incorrect bool",
-			rule: attrvalue.NewSimpleRule("foo", "bar", []bool{true}, "", false),
+			rule: attrvalue.NewSimpleRule("foo", "bar", []bool{true}, "", false, ""),
 			content: `
 	variable "test" {
 		type    = bool
@@ -136,14 +136,14 @@ resource "foo" "example" {
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    attrvalue.NewSimpleRule("foo", "bar", []bool{true}, "", false),
+					Rule:    attrvalue.NewSimpleRule("foo", "bar", []bool{true}, "", false, ""),
 					Message: "false is an invalid attribute value of `bar` - expecting (one of) [true]",
 				},
 			},
 		},
 		{
 			name: "null value",
-			rule: attrvalue.NewSimpleRule("foo", "bar", []bool{true}, "", false),
+			rule: attrvalue.NewSimpleRule("foo", "bar", []bool{true}, "", false, ""),
 			content: `
 	variable "test" {
 		type    = bool
@@ -156,7 +156,7 @@ resource "foo" "example" {
 		},
 		{
 			name: "optional value",
-			rule: attrvalue.NewSimpleRule("foo", "bar", []bool{true}, "", false),
+			rule: attrvalue.NewSimpleRule("foo", "bar", []bool{true}, "", false, ""),
 			content: `
 	variable "test" {
 		type    = object({
@@ -171,7 +171,7 @@ resource "foo" "example" {
 		},
 		{
 			name: "missing attribute",
-			rule: attrvalue.NewSimpleRule("foo", "bar", []bool{true}, "", false),
+			rule: attrvalue.NewSimpleRule("foo", "bar", []bool{true}, "", false, ""),
 			content: `
 	resource "foo" "example" {
 
@@ -180,21 +180,21 @@ resource "foo" "example" {
 		},
 		{
 			name: "missing attribute with must exist",
-			rule: attrvalue.NewSimpleRule("foo", "bar", []bool{true}, "", true),
+			rule: attrvalue.NewSimpleRule("foo", "bar", []bool{true}, "", true, ""),
 			content: `
 	resource "foo" "example" {
 
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    attrvalue.NewSimpleRule("foo", "bar", []bool{true}, "", true),
+					Rule:    attrvalue.NewSimpleRule("foo", "bar", []bool{true}, "", true, ""),
 					Message: "The attribute `bar` must be specified",
 				},
 			},
 		},
 		{
 			name: "correct attribute incorrect resource",
-			rule: attrvalue.NewSimpleRule("foo", "bar", []bool{true}, "", false),
+			rule: attrvalue.NewSimpleRule("foo", "bar", []bool{true}, "", false, ""),
 			content: `
 	variable "test" {
     type		= bool

--- a/attrvalue/unknown_value.go
+++ b/attrvalue/unknown_value.go
@@ -13,6 +13,7 @@ import (
 type UnknownValueRule struct {
 	tflint.DefaultRule // Embed the default rule to reuse its implementation
 	baseValue
+	ruleName string
 }
 
 var _ tflint.Rule = (*UnknownValueRule)(nil)
@@ -23,9 +24,10 @@ func (r *UnknownValueRule) GetNestedBlockType() *string {
 }
 
 // NewUnknownValueRule returns a new rule with the given resource type, and attribute name
-func NewUnknownValueRule(resourceType, attributeName, link string) *UnknownValueRule {
+func NewUnknownValueRule(resourceType, attributeName, link string, ruleName string) *UnknownValueRule {
 	return &UnknownValueRule{
 		baseValue: newBaseValue(resourceType, nil, attributeName, true, link, tflint.ERROR),
+		ruleName: ruleName,
 	}
 }
 
@@ -34,17 +36,22 @@ func (r *UnknownValueRule) Link() string {
 }
 
 // NewUnknownValueNestedBlockRule returns a new rule with the given resource type, nested block type, and attribute name
-func NewUnknownValueNestedBlockRule(resourceType, nestedBlockType, attributeName, link string) *UnknownValueRule {
+func NewUnknownValueNestedBlockRule(resourceType, nestedBlockType, attributeName, link string, ruleName string) *UnknownValueRule {
 	return &UnknownValueRule{
 		baseValue: newBaseValue(resourceType, &nestedBlockType, attributeName, true, link, tflint.ERROR),
+		ruleName: ruleName,
 	}
 }
 
 func (r *UnknownValueRule) Name() string {
-	if r.nestedBlockType != nil {
-		return fmt.Sprintf("unknown_value_%s.%s.%s", r.resourceType, *r.nestedBlockType, r.attributeName)
+	if r.ruleName != "" {
+		return r.ruleName
 	}
-	return fmt.Sprintf("unknown_value_%s.%s", r.resourceType, r.attributeName)
+
+	if r.nestedBlockType != nil {
+		return fmt.Sprintf("%s.%s.%s", r.resourceType, *r.nestedBlockType, r.attributeName)
+	}
+	return fmt.Sprintf("%s.%s", r.resourceType, r.attributeName)
 }
 
 func (r *UnknownValueRule) Check(runner tflint.Runner) error {

--- a/attrvalue/unknown_value.go
+++ b/attrvalue/unknown_value.go
@@ -27,7 +27,7 @@ func (r *UnknownValueRule) GetNestedBlockType() *string {
 func NewUnknownValueRule(resourceType, attributeName, link string, ruleName string) *UnknownValueRule {
 	return &UnknownValueRule{
 		baseValue: newBaseValue(resourceType, nil, attributeName, true, link, tflint.ERROR),
-		ruleName: ruleName,
+		ruleName:  ruleName,
 	}
 }
 
@@ -39,7 +39,7 @@ func (r *UnknownValueRule) Link() string {
 func NewUnknownValueNestedBlockRule(resourceType, nestedBlockType, attributeName, link string, ruleName string) *UnknownValueRule {
 	return &UnknownValueRule{
 		baseValue: newBaseValue(resourceType, &nestedBlockType, attributeName, true, link, tflint.ERROR),
-		ruleName: ruleName,
+		ruleName:  ruleName,
 	}
 }
 

--- a/attrvalue/unknown_value_test.go
+++ b/attrvalue/unknown_value_test.go
@@ -19,7 +19,7 @@ func TestUnknownValueRule(t *testing.T) {
 	}{
 		{
 			name: "unknown string value",
-			rule: attrvalue.NewUnknownValueRule("foo", "bar", ""),
+			rule: attrvalue.NewUnknownValueRule("foo", "bar", "", ""),
 			content: `
 	variable "test" {
 		type    = string
@@ -32,7 +32,7 @@ func TestUnknownValueRule(t *testing.T) {
 		},
 		{
 			name: "null value with local",
-			rule: attrvalue.NewUnknownValueRule("foo", "bar", ""),
+			rule: attrvalue.NewUnknownValueRule("foo", "bar", "", ""),
 			content: `
 		locals {
 		 bar = null
@@ -43,14 +43,14 @@ func TestUnknownValueRule(t *testing.T) {
 		}`,
 			expected: helper.Issues{
 				{
-					Rule:    attrvalue.NewUnknownValueRule("foo", "bar", ""),
+					Rule:    attrvalue.NewUnknownValueRule("foo", "bar", "", ""),
 					Message: "invalid attribute value of `bar` - expecting unknown",
 				},
 			},
 		},
 		{
 			name: "default value",
-			rule: attrvalue.NewUnknownValueRule("foo", "bar", ""),
+			rule: attrvalue.NewUnknownValueRule("foo", "bar", "", ""),
 			content: `
 		variable "test" {
 			type    = string
@@ -61,14 +61,14 @@ func TestUnknownValueRule(t *testing.T) {
 		}`,
 			expected: helper.Issues{
 				{
-					Rule:    attrvalue.NewUnknownValueRule("foo", "bar", ""),
+					Rule:    attrvalue.NewUnknownValueRule("foo", "bar", "", ""),
 					Message: "invalid attribute value of `bar` - expecting unknown",
 				},
 			},
 		},
 		{
 			name: "unknown number value",
-			rule: attrvalue.NewUnknownValueRule("foo", "bar", ""),
+			rule: attrvalue.NewUnknownValueRule("foo", "bar", "", ""),
 			content: `
 		variable "test" {
 			type    = number
@@ -80,7 +80,7 @@ func TestUnknownValueRule(t *testing.T) {
 		},
 		{
 			name: "not null (number)",
-			rule: attrvalue.NewUnknownValueRule("foo", "bar", ""),
+			rule: attrvalue.NewUnknownValueRule("foo", "bar", "", ""),
 			content: `
 		variable "test" {
 			type    = number
@@ -91,14 +91,14 @@ func TestUnknownValueRule(t *testing.T) {
 		}`,
 			expected: helper.Issues{
 				{
-					Rule:    attrvalue.NewUnknownValueRule("foo", "bar", ""),
+					Rule:    attrvalue.NewUnknownValueRule("foo", "bar", "", ""),
 					Message: "invalid attribute value of `bar` - expecting unknown",
 				},
 			},
 		},
 		{
 			name: "attribute not found",
-			rule: attrvalue.NewUnknownValueRule("foo", "bar", ""),
+			rule: attrvalue.NewUnknownValueRule("foo", "bar", "", ""),
 			content: `
 		variable "test" {
 			type    = bool
@@ -110,7 +110,7 @@ func TestUnknownValueRule(t *testing.T) {
 		},
 		{
 			name:     "empty config",
-			rule:     attrvalue.NewUnknownValueRule("foo", "bar", ""),
+			rule:     attrvalue.NewUnknownValueRule("foo", "bar", "", ""),
 			content:  ``,
 			expected: helper.Issues{},
 		},

--- a/integration/optional-defaults-incorrect/result.json
+++ b/integration/optional-defaults-incorrect/result.json
@@ -17,7 +17,7 @@
       },
       "rule": {
         "link": "https://azure.github.io/Azure-Proactive-Resiliency-Library/services/networking/load-balancer/#lb-1---use-standard-load-balancer-sku",
-        "name": "simple_value_azurerm_lb.sku",
+        "name": "azurerm_lb.sku",
         "severity": "error"
       }
     }

--- a/integration/unknownrule-null-incorrect/result.json
+++ b/integration/unknownrule-null-incorrect/result.json
@@ -17,7 +17,7 @@
       },
       "rule": {
         "link": "https://azure.github.io/Azure-Proactive-Resiliency-Library/services/compute/virtual-machines/#vm-2---deploy-vms-across-availability-zones",
-        "name": "unknown_value_azurerm_virtual_machine.zone",
+        "name": "azurerm_virtual_machine.zone",
         "severity": "error"
       }
     }

--- a/rules/rule_register.go
+++ b/rules/rule_register.go
@@ -26,7 +26,7 @@ var Rules = func() []tflint.Rule {
 			NewTerraformDotTfRule(),
 			NewModuleSourceRule(),
 		},
-		waf.Rules,
+		waf.GetRules(),
 		interfaces.Rules,
 		outputs.Rules,
 	)

--- a/rules/rule_register_test.go
+++ b/rules/rule_register_test.go
@@ -1,0 +1,20 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/Azure/tflint-ruleset-avm/rules"
+)
+
+func TestDuplicateRuleNames(t *testing.T) {
+	rules := rules.Rules
+
+	names := make(map[string]bool)
+	for _, rule := range rules {
+		name := rule.Name()
+		if names[name] {
+			t.Errorf("duplicate rule name: %s", name)
+		}
+		names[name] = true
+	}
+}

--- a/waf/azurerm_application_gateway.go
+++ b/waf/azurerm_application_gateway.go
@@ -2,16 +2,17 @@ package waf
 
 import "github.com/Azure/tflint-ruleset-avm/attrvalue"
 
-func AzurermApplicationGatewayZones() *attrvalue.SetRule[int] {
+func (wf WafRules) AzurermApplicationGatewayZones() *attrvalue.SetRule[int] {
 	return attrvalue.NewSetRule(
 		"azurerm_application_gateway",
 		"zones",
 		[][]int{{1, 2, 3}},
 		"https://azure.github.io/Azure-Proactive-Resiliency-Library/services/networking/application-gateway/#agw-1---set-a-minimum-instance-count-of-2",
+		"",
 	)
 }
 
-func AzurermApplicationGatewaySku() *attrvalue.SimpleRule[string] {
+func (wf WafRules) AzurermApplicationGatewaySku() *attrvalue.SimpleRule[string] {
 	return attrvalue.NewSimpleNestedBlockRule[string](
 		"azurerm_application_gateway",
 		"sku",
@@ -19,5 +20,6 @@ func AzurermApplicationGatewaySku() *attrvalue.SimpleRule[string] {
 		[]string{"Standard_v2", "WAF_v2"},
 		"https://azure.github.io/Azure-Proactive-Resiliency-Library/services/networking/application-gateway/#agw-4---use-application-gw-v2-instead-of-v1",
 		false,
+		"",
 	)
 }

--- a/waf/azurerm_cosmosdb_account.go
+++ b/waf/azurerm_cosmosdb_account.go
@@ -4,7 +4,7 @@ import (
 	"github.com/Azure/tflint-ruleset-avm/attrvalue"
 )
 
-func AzurermCosmosDbAccountBackupMode() *attrvalue.SimpleRule[string] {
+func (wf WafRules) AzurermCosmosDbAccountBackupMode() *attrvalue.SimpleRule[string] {
 	return attrvalue.NewSimpleNestedBlockRule[string](
 		"azurerm_cosmosdb_account",
 		"backup",
@@ -12,5 +12,6 @@ func AzurermCosmosDbAccountBackupMode() *attrvalue.SimpleRule[string] {
 		[]string{"Continuous"},
 		"https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/azure-resources/DocumentDB/databaseAccounts/#configure-continuous-backup-mode",
 		true,
+		"",
 	)
 }

--- a/waf/azurerm_cosmosdb_account_test.go
+++ b/waf/azurerm_cosmosdb_account_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAzurermCosmosDbAccountBackupMode(t *testing.T) {
+	wafRules := waf.WafRules{}
+
 	testCases := []struct {
 		name     string
 		rule     tflint.Rule
@@ -20,7 +22,7 @@ func TestAzurermCosmosDbAccountBackupMode(t *testing.T) {
 	}{
 		{
 			name: "correct setting",
-			rule: waf.AzurermCosmosDbAccountBackupMode(),
+			rule: wafRules.AzurermCosmosDbAccountBackupMode(),
 			content: `
 	variable "backup_type" {
 		type    = string
@@ -35,7 +37,7 @@ func TestAzurermCosmosDbAccountBackupMode(t *testing.T) {
 		},
 		{
 			name: "incorrect setting",
-			rule: waf.AzurermCosmosDbAccountBackupMode(),
+			rule: wafRules.AzurermCosmosDbAccountBackupMode(),
 			content: `
     variable "backup_type" {
 		type    = string
@@ -48,28 +50,28 @@ func TestAzurermCosmosDbAccountBackupMode(t *testing.T) {
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    waf.AzurermCosmosDbAccountBackupMode(),
+					Rule:    wafRules.AzurermCosmosDbAccountBackupMode(),
 					Message: "Periodic is an invalid attribute value of `type` - expecting (one of) [Continuous]",
 				},
 			},
 		},
 		{
 			name: "missing block",
-			rule: waf.AzurermCosmosDbAccountBackupMode(),
+			rule: wafRules.AzurermCosmosDbAccountBackupMode(),
 			content: `
 	resource "azurerm_cosmosdb_account" "example" {
 
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    waf.AzurermCosmosDbAccountBackupMode(),
+					Rule:    wafRules.AzurermCosmosDbAccountBackupMode(),
 					Message: "The attribute `type` must be specified",
 				},
 			},
 		},
 		{
 			name: "missing block attribute",
-			rule: waf.AzurermCosmosDbAccountBackupMode(),
+			rule: wafRules.AzurermCosmosDbAccountBackupMode(),
 			content: `
 	resource "azurerm_cosmosdb_account" "example" {
 		backup {
@@ -78,14 +80,14 @@ func TestAzurermCosmosDbAccountBackupMode(t *testing.T) {
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    waf.AzurermCosmosDbAccountBackupMode(),
+					Rule:    wafRules.AzurermCosmosDbAccountBackupMode(),
 					Message: "The attribute `type` must be specified",
 				},
 			},
 		},
 		{
 			name: "missing resource",
-			rule: waf.AzurermCosmosDbAccountBackupMode(),
+			rule: wafRules.AzurermCosmosDbAccountBackupMode(),
 			content: `
 	resource "something_else" "example" {
 

--- a/waf/azurerm_kubernetes_cluster.go
+++ b/waf/azurerm_kubernetes_cluster.go
@@ -2,11 +2,12 @@ package waf
 
 import "github.com/Azure/tflint-ruleset-avm/attrvalue"
 
-func AzurermKubernetesClusterZones() *attrvalue.SetRule[int] {
+func (wf WafRules) AzurermKubernetesClusterZones() *attrvalue.SetRule[int] {
 	return attrvalue.NewSetRule(
 		"azurerm_kubernetes_cluster",
 		"zones",
 		[][]int{{1, 2, 3}},
 		"https://azure.github.io/Azure-Proactive-Resiliency-Library/services/container/aks/#aks-1---deploy-aks-cluster-across-availability-zones",
+		"",
 	)
 }

--- a/waf/azurerm_lb.go
+++ b/waf/azurerm_lb.go
@@ -4,12 +4,13 @@ import (
 	"github.com/Azure/tflint-ruleset-avm/attrvalue"
 )
 
-func AzurermLbSku() *attrvalue.SimpleRule[string] {
+func (wf WafRules) AzurermLbSku() *attrvalue.SimpleRule[string] {
 	return attrvalue.NewSimpleRule[string](
 		"azurerm_lb",
 		"sku",
 		[]string{"Standard"},
 		"https://azure.github.io/Azure-Proactive-Resiliency-Library/services/networking/load-balancer/#lb-1---use-standard-load-balancer-sku",
 		false,
+		"",
 	)
 }

--- a/waf/azurerm_mysql_flexible_server.go
+++ b/waf/azurerm_mysql_flexible_server.go
@@ -4,7 +4,7 @@ import (
 	"github.com/Azure/tflint-ruleset-avm/attrvalue"
 )
 
-func AzurermMySqlFlexibleServerZoneRedundancy() *attrvalue.SimpleRule[string] {
+func (wf WafRules) AzurermMySqlFlexibleServerZoneRedundancy() *attrvalue.SimpleRule[string] {
 	return attrvalue.NewSimpleNestedBlockRule[string](
 		"azurerm_mysql_flexible_server",
 		"high_availability",
@@ -12,10 +12,11 @@ func AzurermMySqlFlexibleServerZoneRedundancy() *attrvalue.SimpleRule[string] {
 		[]string{"ZoneRedundant"},
 		"https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/azure-resources/DBforMySQL/flexibleServers/#enable-ha-with-zone-redundancy",
 		true,
+		"",
 	)
 }
 
-func AzurermMySqlFlexibleServerCustomMaintenanceSchedule() *attrvalue.SimpleRule[string] {
+func (wf WafRules) AzurermMySqlFlexibleServerCustomMaintenanceSchedule() *attrvalue.SimpleRule[string] {
 	return attrvalue.NewSimpleNestedBlockRule[string](
 		"azurerm_mysql_flexible_server",
 		"maintenance_window",
@@ -23,5 +24,6 @@ func AzurermMySqlFlexibleServerCustomMaintenanceSchedule() *attrvalue.SimpleRule
 		[]string{"0", "1", "2", "3", "4", "5", "6"},
 		"https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/azure-resources/DBforMySQL/flexibleServers/#enable-custom-maintenance-schedule",
 		true,
+		"",
 	)
 }

--- a/waf/azurerm_mysql_flexible_server_test.go
+++ b/waf/azurerm_mysql_flexible_server_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAzurermMySqlFlexibleServerZoneRedundancy(t *testing.T) {
+	wafRules := waf.WafRules{}
+
 	testCases := []struct {
 		name     string
 		rule     tflint.Rule
@@ -20,7 +22,7 @@ func TestAzurermMySqlFlexibleServerZoneRedundancy(t *testing.T) {
 	}{
 		{
 			name: "correct setting",
-			rule: waf.AzurermMySqlFlexibleServerZoneRedundancy(),
+			rule: wafRules.AzurermMySqlFlexibleServerZoneRedundancy(),
 			content: `
 	variable "high_availability_mode" {
 		type    = string
@@ -35,7 +37,7 @@ func TestAzurermMySqlFlexibleServerZoneRedundancy(t *testing.T) {
 		},
 		{
 			name: "incorrect setting",
-			rule: waf.AzurermMySqlFlexibleServerZoneRedundancy(),
+			rule: wafRules.AzurermMySqlFlexibleServerZoneRedundancy(),
 			content: `
     variable "high_availability_mode" {
 		type    = string
@@ -48,21 +50,21 @@ func TestAzurermMySqlFlexibleServerZoneRedundancy(t *testing.T) {
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    waf.AzurermMySqlFlexibleServerZoneRedundancy(),
+					Rule:    wafRules.AzurermMySqlFlexibleServerZoneRedundancy(),
 					Message: "SameZone is an invalid attribute value of `mode` - expecting (one of) [ZoneRedundant]",
 				},
 			},
 		},
 		{
 			name: "missing block",
-			rule: waf.AzurermMySqlFlexibleServerZoneRedundancy(),
+			rule: wafRules.AzurermMySqlFlexibleServerZoneRedundancy(),
 			content: `
 	resource "azurerm_mysql_flexible_server" "example" {
 
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    waf.AzurermMySqlFlexibleServerZoneRedundancy(),
+					Rule:    wafRules.AzurermMySqlFlexibleServerZoneRedundancy(),
 					Message: "The attribute `mode` must be specified",
 				},
 			},
@@ -85,6 +87,8 @@ func TestAzurermMySqlFlexibleServerZoneRedundancy(t *testing.T) {
 }
 
 func TestAzurermMySqlFlexibleServerCustomMaintenanceSchedule(t *testing.T) {
+	wafRules := waf.WafRules{}
+
 	testCases := []struct {
 		name     string
 		rule     tflint.Rule
@@ -93,7 +97,7 @@ func TestAzurermMySqlFlexibleServerCustomMaintenanceSchedule(t *testing.T) {
 	}{
 		{
 			name: "correct setting",
-			rule: waf.AzurermMySqlFlexibleServerCustomMaintenanceSchedule(),
+			rule: wafRules.AzurermMySqlFlexibleServerCustomMaintenanceSchedule(),
 			content: `
 	variable "maintenance_window" {
 		type    = string
@@ -108,7 +112,7 @@ func TestAzurermMySqlFlexibleServerCustomMaintenanceSchedule(t *testing.T) {
 		},
 		{
 			name: "incorrect setting",
-			rule: waf.AzurermMySqlFlexibleServerCustomMaintenanceSchedule(),
+			rule: wafRules.AzurermMySqlFlexibleServerCustomMaintenanceSchedule(),
 			content: `
     variable "maintenance_window" {
 		type    = string
@@ -121,21 +125,21 @@ func TestAzurermMySqlFlexibleServerCustomMaintenanceSchedule(t *testing.T) {
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    waf.AzurermMySqlFlexibleServerCustomMaintenanceSchedule(),
+					Rule:    wafRules.AzurermMySqlFlexibleServerCustomMaintenanceSchedule(),
 					Message: "20 is an invalid attribute value of `day_of_week` - expecting (one of) [0 1 2 3 4 5 6]",
 				},
 			},
 		},
 		{
 			name: "missing block",
-			rule: waf.AzurermMySqlFlexibleServerCustomMaintenanceSchedule(),
+			rule: wafRules.AzurermMySqlFlexibleServerCustomMaintenanceSchedule(),
 			content: `
 	resource "azurerm_mysql_flexible_server" "example" {
 
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    waf.AzurermMySqlFlexibleServerCustomMaintenanceSchedule(),
+					Rule:    wafRules.AzurermMySqlFlexibleServerCustomMaintenanceSchedule(),
 					Message: "The attribute `day_of_week` must be specified",
 				},
 			},

--- a/waf/azurerm_postgresql_flexible_server.go
+++ b/waf/azurerm_postgresql_flexible_server.go
@@ -4,7 +4,7 @@ import (
 	"github.com/Azure/tflint-ruleset-avm/attrvalue"
 )
 
-func AzurermPostgreSqlFlexibleServerZoneRedundancy() *attrvalue.SimpleRule[string] {
+func (wf WafRules) AzurermPostgreSqlFlexibleServerZoneRedundancy() *attrvalue.SimpleRule[string] {
 	return attrvalue.NewSimpleNestedBlockRule[string](
 		"azurerm_postgresql_flexible_server",
 		"high_availability",
@@ -12,10 +12,11 @@ func AzurermPostgreSqlFlexibleServerZoneRedundancy() *attrvalue.SimpleRule[strin
 		[]string{"ZoneRedundant"},
 		"https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/azure-resources/DBforPostgreSQL/flexibleServers/#enable-ha-with-zone-redundancy",
 		true,
+		"",
 	)
 }
 
-func AzurermPostgreSqlFlexibleServerCustomMaintenanceSchedule() *attrvalue.SimpleRule[string] {
+func (wf WafRules) AzurermPostgreSqlFlexibleServerCustomMaintenanceSchedule() *attrvalue.SimpleRule[string] {
 	return attrvalue.NewSimpleNestedBlockRule[string](
 		"azurerm_postgresql_flexible_server",
 		"maintenance_window",
@@ -23,5 +24,6 @@ func AzurermPostgreSqlFlexibleServerCustomMaintenanceSchedule() *attrvalue.Simpl
 		[]string{"0", "1", "2", "3", "4", "5", "6"},
 		"https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/azure-resources/DBforPostgreSQL/flexibleServers/#enable-custom-maintenance-schedule",
 		true,
+		"",
 	)
 }

--- a/waf/azurerm_postgresql_flexible_server_test.go
+++ b/waf/azurerm_postgresql_flexible_server_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAzurermPostgreSqlFlexibleServerZoneRedundancy(t *testing.T) {
+	wafRules := waf.WafRules{}
+
 	testCases := []struct {
 		name     string
 		rule     tflint.Rule
@@ -20,7 +22,7 @@ func TestAzurermPostgreSqlFlexibleServerZoneRedundancy(t *testing.T) {
 	}{
 		{
 			name: "correct setting",
-			rule: waf.AzurermPostgreSqlFlexibleServerZoneRedundancy(),
+			rule: wafRules.AzurermPostgreSqlFlexibleServerZoneRedundancy(),
 			content: `
 	variable "high_availability_mode" {
 		type    = string
@@ -35,7 +37,7 @@ func TestAzurermPostgreSqlFlexibleServerZoneRedundancy(t *testing.T) {
 		},
 		{
 			name: "incorrect setting",
-			rule: waf.AzurermPostgreSqlFlexibleServerZoneRedundancy(),
+			rule: wafRules.AzurermPostgreSqlFlexibleServerZoneRedundancy(),
 			content: `
     variable "high_availability_mode" {
 		type    = string
@@ -48,21 +50,21 @@ func TestAzurermPostgreSqlFlexibleServerZoneRedundancy(t *testing.T) {
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    waf.AzurermPostgreSqlFlexibleServerZoneRedundancy(),
+					Rule:    wafRules.AzurermPostgreSqlFlexibleServerZoneRedundancy(),
 					Message: "SameZone is an invalid attribute value of `mode` - expecting (one of) [ZoneRedundant]",
 				},
 			},
 		},
 		{
 			name: "missing block",
-			rule: waf.AzurermPostgreSqlFlexibleServerZoneRedundancy(),
+			rule: wafRules.AzurermPostgreSqlFlexibleServerZoneRedundancy(),
 			content: `
 	resource "azurerm_postgresql_flexible_server" "example" {
 
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    waf.AzurermPostgreSqlFlexibleServerZoneRedundancy(),
+					Rule:    wafRules.AzurermPostgreSqlFlexibleServerZoneRedundancy(),
 					Message: "The attribute `mode` must be specified",
 				},
 			},
@@ -85,6 +87,8 @@ func TestAzurermPostgreSqlFlexibleServerZoneRedundancy(t *testing.T) {
 }
 
 func TestAzurermPostgreSqlFlexibleServerCustomMaintenanceSchedule(t *testing.T) {
+	wafRules := waf.WafRules{}
+
 	testCases := []struct {
 		name     string
 		rule     tflint.Rule
@@ -93,7 +97,7 @@ func TestAzurermPostgreSqlFlexibleServerCustomMaintenanceSchedule(t *testing.T) 
 	}{
 		{
 			name: "correct setting",
-			rule: waf.AzurermPostgreSqlFlexibleServerCustomMaintenanceSchedule(),
+			rule: wafRules.AzurermPostgreSqlFlexibleServerCustomMaintenanceSchedule(),
 			content: `
 	variable "maintenance_window" {
 		type    = string
@@ -108,7 +112,7 @@ func TestAzurermPostgreSqlFlexibleServerCustomMaintenanceSchedule(t *testing.T) 
 		},
 		{
 			name: "incorrect setting",
-			rule: waf.AzurermPostgreSqlFlexibleServerCustomMaintenanceSchedule(),
+			rule: wafRules.AzurermPostgreSqlFlexibleServerCustomMaintenanceSchedule(),
 			content: `
     variable "maintenance_window" {
 		type    = string
@@ -121,21 +125,21 @@ func TestAzurermPostgreSqlFlexibleServerCustomMaintenanceSchedule(t *testing.T) 
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    waf.AzurermPostgreSqlFlexibleServerCustomMaintenanceSchedule(),
+					Rule:    wafRules.AzurermPostgreSqlFlexibleServerCustomMaintenanceSchedule(),
 					Message: "20 is an invalid attribute value of `day_of_week` - expecting (one of) [0 1 2 3 4 5 6]",
 				},
 			},
 		},
 		{
 			name: "missing block",
-			rule: waf.AzurermPostgreSqlFlexibleServerCustomMaintenanceSchedule(),
+			rule: wafRules.AzurermPostgreSqlFlexibleServerCustomMaintenanceSchedule(),
 			content: `
 	resource "azurerm_postgresql_flexible_server" "example" {
 
 	}`,
 			expected: helper.Issues{
 				{
-					Rule:    waf.AzurermPostgreSqlFlexibleServerCustomMaintenanceSchedule(),
+					Rule:    wafRules.AzurermPostgreSqlFlexibleServerCustomMaintenanceSchedule(),
 					Message: "The attribute `day_of_week` must be specified",
 				},
 			},

--- a/waf/azurerm_public_ip.go
+++ b/waf/azurerm_public_ip.go
@@ -4,21 +4,23 @@ import (
 	"github.com/Azure/tflint-ruleset-avm/attrvalue"
 )
 
-func AzurermPublicIpSku() *attrvalue.SimpleRule[string] {
+func (wf WafRules) AzurermPublicIpSku() *attrvalue.SimpleRule[string] {
 	return attrvalue.NewSimpleRule[string](
 		"azurerm_public_ip",
 		"sku",
 		[]string{"Standard"},
 		"https://azure.github.io/Azure-Proactive-Resiliency-Library/services/networking/public-ip/#pip-1---use-standard-sku-and-zone-redundant-ips-when-applicable",
 		false,
+		"",
 	)
 }
 
-func AzurermPublicIpZones() *attrvalue.SetRule[int] {
+func (wf WafRules) AzurermPublicIpZones() *attrvalue.SetRule[int] {
 	return attrvalue.NewSetRule(
 		"azurerm_public_ip",
 		"zones",
 		[][]int{{1, 2, 3}},
 		"https://azure.github.io/Azure-Proactive-Resiliency-Library/services/networking/public-ip/#pip-1---use-standard-sku-and-zone-redundant-ips-when-applicable",
+		"",
 	)
 }

--- a/waf/azurerm_service_plan.go
+++ b/waf/azurerm_service_plan.go
@@ -4,12 +4,13 @@ import (
 	"github.com/Azure/tflint-ruleset-avm/attrvalue"
 )
 
-func AzurermServicePlanZoneBalancingEnabled() *attrvalue.SimpleRule[bool] {
+func (wf WafRules) AzurermServicePlanZoneBalancingEnabled() *attrvalue.SimpleRule[bool] {
 	return attrvalue.NewSimpleRule[bool](
 		"azurerm_service_plan",
 		"zone_balancing_enabled",
 		[]bool{true},
 		"https://azure.github.io/Azure-Proactive-Resiliency-Library/services/web/app-service-plan/#asp-1---migrate-app-service-to-availability-zone-support",
 		false,
+		"",
 	)
 }

--- a/waf/azurerm_storage_account.go
+++ b/waf/azurerm_storage_account.go
@@ -4,12 +4,13 @@ import (
 	"github.com/Azure/tflint-ruleset-avm/attrvalue"
 )
 
-func AzurermStorageAccountAccountReplicationType() *attrvalue.SimpleRule[string] {
+func (wf WafRules) AzurermStorageAccountAccountReplicationType() *attrvalue.SimpleRule[string] {
 	return attrvalue.NewSimpleRule[string](
 		"azurerm_storage_account",
 		"account_replication_type",
 		[]string{"ZRS"},
 		"https://azure.github.io/Azure-Proactive-Resiliency-Library/services/storage/storage-account/#st-1---ensure-that-storage-accounts-are-zone-or-region-redundant",
 		false,
+		"",
 	)
 }

--- a/waf/azurerm_virtual_machine.go
+++ b/waf/azurerm_virtual_machine.go
@@ -2,18 +2,20 @@ package waf
 
 import "github.com/Azure/tflint-ruleset-avm/attrvalue"
 
-func AzurermVirtualMachineZoneUnknown() *attrvalue.UnknownValueRule {
+func (wf WafRules) AzurermVirtualMachineZoneUnknown() *attrvalue.UnknownValueRule {
 	return attrvalue.NewUnknownValueRule(
 		"azurerm_virtual_machine",
 		"zone",
 		"https://azure.github.io/Azure-Proactive-Resiliency-Library/services/compute/virtual-machines/#vm-2---deploy-vms-across-availability-zones",
+		"",
 	)
 }
 
-func AzurermVirtualMachineZonesUnknown() *attrvalue.UnknownValueRule {
+func (wf WafRules) AzurermVirtualMachineZonesUnknown() *attrvalue.UnknownValueRule {
 	return attrvalue.NewUnknownValueRule(
 		"azurerm_virtual_machine",
 		"zones",
 		"https://azure.github.io/Azure-Proactive-Resiliency-Library/services/compute/virtual-machines/#vm-2---deploy-vms-across-availability-zones",
+		"",
 	)
 }

--- a/waf/azurerm_virtual_network_gateway.go
+++ b/waf/azurerm_virtual_network_gateway.go
@@ -4,12 +4,13 @@ import (
 	"github.com/Azure/tflint-ruleset-avm/attrvalue"
 )
 
-func AzurermVirtualNetworkGatewaySku() *attrvalue.SimpleRule[string] {
+func (wf WafRules) AzurermVirtualNetworkGatewaySku() *attrvalue.SimpleRule[string] {
 	return attrvalue.NewSimpleRule[string](
 		"azurerm_virtual_network_gateway",
 		"sku",
 		[]string{"ErGw1AZ", "ErGw2AZ", "ErGw3AZ", "VpnGw1AZ", "VpnGw2AZ", "VpnGw3AZ", "VpnGw4AZ", "VpnGw5AZ"},
 		"https://azure.github.io/Azure-Proactive-Resiliency-Library/services/networking/expressroute-gateway/#ergw-2---use-zone-redundant-gateway-skus",
 		false,
+		"",
 	)
 }

--- a/waf/waf.go
+++ b/waf/waf.go
@@ -8,10 +8,11 @@ import (
 
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
+
 // WafRules is a helper struct. Methods are created on this type that generate the rules for the WAF package.
 // We then use reflection to automatically generate a slice of the rules to add the the ruleset.
 
-GetRules uses reflection to iterate over all the methods of the WafRules struct and add them to a slice of Rules to be included in the ruleset.
+// GetRules uses reflection to iterate over all the methods of the WafRules struct and add them to a slice of Rules to be included in the ruleset.
 // See `GetRules()` for more detail.
 type WafRules struct{}
 

--- a/waf/waf.go
+++ b/waf/waf.go
@@ -8,7 +8,10 @@ import (
 
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
-
+// WafRules is a helper struct. Methods are created on this type that generate the rules for the WAF package.
+// We then use reflection to automatically generate a slice of the rules to add the the ruleset.
+// This avoids having to manually maintain a list of rules.
+// See `GetRules()` for more detail.
 type WafRules struct{}
 
 func GetRules() []tflint.Rule {

--- a/waf/waf.go
+++ b/waf/waf.go
@@ -10,7 +10,8 @@ import (
 )
 // WafRules is a helper struct. Methods are created on this type that generate the rules for the WAF package.
 // We then use reflection to automatically generate a slice of the rules to add the the ruleset.
-// This avoids having to manually maintain a list of rules.
+
+GetRules uses reflection to iterate over all the methods of the WafRules struct and add them to a slice of Rules to be included in the ruleset.
 // See `GetRules()` for more detail.
 type WafRules struct{}
 

--- a/waf/waf.go
+++ b/waf/waf.go
@@ -3,21 +3,24 @@
 // Then add the rule to the Rules slice.
 package waf
 
-import "github.com/terraform-linters/tflint-plugin-sdk/tflint"
+import (
+	"reflect"
 
-// Rules is the list of rules for Well Architected Alignment.
-// Make sure to add any new rules to this list.
-// Please sort the list to be kind to your fellow maintainers.
-var Rules = []tflint.Rule{
-	AzurermApplicationGatewaySku(),
-	AzurermApplicationGatewayZones(),
-	AzurermKubernetesClusterZones(),
-	AzurermLbSku(),
-	AzurermPublicIpSku(),
-	AzurermPublicIpZones(),
-	AzurermServicePlanZoneBalancingEnabled(),
-	AzurermStorageAccountAccountReplicationType(),
-	AzurermVirtualMachineZoneUnknown(),
-	AzurermVirtualMachineZonesUnknown(),
-	AzurermVirtualNetworkGatewaySku(),
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+type WafRules struct{}
+
+func GetRules() []tflint.Rule {
+	rules := []tflint.Rule{}
+
+	wafRules := reflect.TypeOf(WafRules{})
+
+	for i := 0; i < wafRules.NumMethod(); i++ {
+		method := wafRules.Method(i)
+		rule := reflect.ValueOf(WafRules{}).MethodByName(method.Name).Call([]reflect.Value{})
+		rules = append(rules, rule[0].Interface().(tflint.Rule))
+	}
+
+	return rules
 }

--- a/waf/waf.go
+++ b/waf/waf.go
@@ -19,14 +19,11 @@ func GetRules() []tflint.Rule {
 	// Create a slice to add the rules to
 	rules := []tflint.Rule{}
 
-	// Get the type of the WafRules struct, so we can iterate it's functions
-	wafRulesType := reflect.TypeOf(WafRules{})
-
-	// Get an instance of the WefRules struct we can use to call functions on
+	// Get an instance of the WefRules struct we can use to iterate and call functions on
 	wafRulesInstance := reflect.ValueOf(WafRules{})
 
 	// Iterate over all the functions of the WafRules struct
-	for i := 0; i < wafRulesType.NumMethod(); i++ {
+	for i := 0; i < wafRulesInstance.NumMethod(); i++ {
 		// Get an instance of the function
 		methodInstance := wafRulesInstance.Method(i)
 

--- a/waf/waf_test.go
+++ b/waf/waf_test.go
@@ -2,12 +2,20 @@ package waf_test
 
 import (
 	"os"
+	"testing"
 
+	"github.com/Azure/tflint-ruleset-avm/waf"
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 )
 
 func mockFs(c string) afero.Afero {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "main.tf", []byte(c), os.ModePerm)
 	return afero.Afero{Fs: fs}
+}
+
+func TestGetRules(t *testing.T) {
+	rules := waf.GetRules()
+	assert.Truef(t, len(rules) > 0, "rules should not be empty")
 }


### PR DESCRIPTION
- Use reflection to add WAF rules dynamically
- Make the name nicer by removing the prefix
- Add the ability to override a rule name in case of a collision