### PR TITLE
Add `valid_template_interpolation` rule

### DIFF
--- a/attrvalue/base_value.go
+++ b/attrvalue/base_value.go
@@ -98,7 +98,7 @@ func (b *baseValue) attributeExistsWhereResourceIsSpecified(r tflint.Runner) (bo
 
 func (b *baseValue) checkAttributes(r tflint.Runner, ct cty.Type, c func(*hclext.Attribute, cty.Value) error) error {
 	ctx, attrs, diags := fetchAttrsAndContext(b, r)
-	if diags.HasErrors() && b.failOnEvaluationError {
+	if diags.HasErrors() {
 		if b.failOnEvaluationError {
 			return fmt.Errorf("could not get partial content: %s", diags)
 		}

--- a/attrvalue/module_content.go
+++ b/attrvalue/module_content.go
@@ -2,16 +2,10 @@ package attrvalue
 
 import (
 	"github.com/hashicorp/hcl/v2"
-	"github.com/spf13/afero"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/terraform-linters/tflint/terraform"
-	"github.com/terraform-linters/tflint/terraform/addrs"
 )
-
-var AppFs = afero.Afero{
-	Fs: afero.NewOsFs(),
-}
 
 type AttrValueRule interface {
 	GetResourceType() string
@@ -19,204 +13,33 @@ type AttrValueRule interface {
 	GetAttributeName() string
 }
 
-// getSimpleResources returns a slice of resources with the given resource type and the attribute if it exists.
-func getSimpleResourcesWithAttributes(module *terraform.Module, resourceType string, attributeName string, ctx *terraform.Evaluator) ([]*hclext.Block, hcl.Diagnostics) {
-	resources, diags := getResourcesOfResourceTypeIncludingSpecifiedAttribute(module, attributeName, ctx)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-	filteredResources := make([]*hclext.Block, 0, len(resources.Blocks))
-	for _, resource := range resources.Blocks {
-		if resource.Labels[0] != resourceType {
-			continue
-		}
-		filteredResources = append(filteredResources, resource)
-	}
-	return filteredResources, nil
-}
-
-// getSimpleAttrs returns a slice of attributes with the given attribute name from the resources of the given resource type.
-func getSimpleAttrs(module *terraform.Module, resourceType string, attributeName string, ctx *terraform.Evaluator) ([]*hclext.Attribute, hcl.Diagnostics) {
-	resources, diags := getResourcesOfResourceTypeIncludingSpecifiedAttribute(module, attributeName, ctx)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-	attrs := make([]*hclext.Attribute, 0, len(resources.Blocks))
-	for _, resource := range resources.Blocks {
-		if resource.Labels[0] != resourceType {
-			continue
-		}
-		if attribute := getAttrFromBlock(resource, attributeName); attribute != nil {
-			attrs = append(attrs, attribute)
-		}
-	}
-	return attrs, nil
-}
-
-// getNestedResourcesWithAttribute returns a slice of resources with the given resource type and the attribute if it exists.
-func getNestedResourcesWithBlockAttributes(ctx *terraform.Evaluator, module *terraform.Module, resourceType, nestedBlockType, attributeName string) ([]*hclext.Block, hcl.Diagnostics) {
-	resources, diags := getResourcesOfResourceTypeIncludingBlocksWithSpecifiedAttribute(module, nestedBlockType, attributeName, ctx)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-	filteredResources := make([]*hclext.Block, 0, len(resources.Blocks))
-	for _, resource := range resources.Blocks {
-		if resource.Labels[0] != resourceType {
-			continue
-		}
-		filteredResources = append(filteredResources, resource)
-	}
-	return filteredResources, nil
-}
-
-// getNestedBlockAttrs returns a slice of attributes with the given attribute name from the nested blocks of the given resource type.
-func getNestedBlockAttrs(ctx *terraform.Evaluator, module *terraform.Module, resourceType, nestedBlockType, attributeName string) ([]*hclext.Attribute, hcl.Diagnostics) {
-	resources, diags := getResourcesOfResourceTypeIncludingBlocksWithSpecifiedAttribute(module, nestedBlockType, attributeName, ctx)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-	attrs := make([]*hclext.Attribute, 0, len(resources.Blocks))
-	for _, resource := range resources.Blocks {
-		if resource.Labels[0] != resourceType {
-			continue
-		}
-		for _, block := range resource.Body.Blocks {
-			if attr := getAttrFromBlock(block, attributeName); attr != nil {
-				attrs = append(attrs, attr)
-			}
-		}
-	}
-	return attrs, nil
-}
-
-// getAttrFromBlock returns the attribute with the given attribute name from the block.
-func getAttrFromBlock(block *hclext.Block, attributeName string) *hclext.Attribute {
-	attribute, exists := block.Body.Attributes[attributeName]
-	if !exists {
-		return nil
-	}
-	return attribute
-}
-
 func fetchAttrsAndContext(r AttrValueRule, runner tflint.Runner) (*terraform.Evaluator, []*hclext.Attribute, hcl.Diagnostics) {
-	// If we are using the tflint test runner then we need to create a new memory file system
-	wd, _ := runner.GetOriginalwd()
-	loader, err := terraform.NewLoader(AppFs, wd)
-	if err != nil {
-		return nil, nil, hcl.Diagnostics{{
-			Summary: err.Error(),
-		}}
-	}
-	config, diags := loader.LoadConfig(".", terraform.CallLocalModule)
-	if diags.HasErrors() {
-		return nil, nil, diags
-	}
-	vvals, diags := terraform.VariableValues(config)
-	if diags.HasErrors() {
-		return nil, nil, diags
-	}
-	ctx := &terraform.Evaluator{
-		Meta: &terraform.ContextMeta{
-			Env:                "",
-			OriginalWorkingDir: wd,
-		},
-		Config:         config,
-		VariableValues: vvals,
-		ModulePath:     addrs.RootModuleInstance,
+	moduleEvaluator, diag := newModuleEvaluator(runner)
+	if diag.HasErrors() {
+		return nil, nil, diag
 	}
 
 	if r.GetNestedBlockType() != nil {
-		attrs, diags := getNestedBlockAttrs(ctx, config.Module, r.GetResourceType(), *r.GetNestedBlockType(), r.GetAttributeName())
-		return ctx, attrs, diags
+		attrs, diags := moduleEvaluator.getNestedBlockAttrs(r.GetResourceType(), *r.GetNestedBlockType(), r.GetAttributeName())
+		return moduleEvaluator.Evaluator, attrs, diags
 	}
 
-	attrs, diags := getSimpleAttrs(config.Module, r.GetResourceType(), r.GetAttributeName(), ctx)
-
-	return ctx, attrs, diags
+	attrs, diags := moduleEvaluator.getSimpleAttrs(r.GetResourceType(), r.GetAttributeName())
+	return moduleEvaluator.Evaluator, attrs, diags
 }
 
-func fetchResourcesAndContext(r AttrValueRule, runner tflint.Runner) (*terraform.Evaluator, []*hclext.Block, hcl.Diagnostics) {
-	// If we are using the tflint test runner then we need to create a new memory file system
-	wd, _ := runner.GetOriginalwd()
-	loader, err := terraform.NewLoader(AppFs, wd)
-	if err != nil {
-		return nil, nil, hcl.Diagnostics{{
-			Summary: err.Error(),
-		}}
-	}
-	config, diags := loader.LoadConfig(".", terraform.CallLocalModule)
-	if diags.HasErrors() {
-		return nil, nil, diags
-	}
-	vvals, diags := terraform.VariableValues(config)
-	if diags.HasErrors() {
-		return nil, nil, diags
-	}
-	ctx := &terraform.Evaluator{
-		Meta: &terraform.ContextMeta{
-			Env:                "",
-			OriginalWorkingDir: wd,
-		},
-		Config:         config,
-		VariableValues: vvals,
-		ModulePath:     addrs.RootModuleInstance,
+func fetchResourcesAndContext(r AttrValueRule, runner tflint.Runner) ([]*hclext.Block, *terraform.Evaluator, hcl.Diagnostics) {
+	moduleEvaluator, diag := newModuleEvaluator(runner)
+	if diag.HasErrors() {
+		return nil, nil, diag
 	}
 
 	if r.GetNestedBlockType() != nil {
-		resources, diags := getNestedResourcesWithBlockAttributes(ctx, config.Module, r.GetResourceType(), *r.GetNestedBlockType(), r.GetAttributeName())
-		return ctx, resources, diags
+		resources, diags := moduleEvaluator.getNestedResourcesWithBlockAttributes(r.GetResourceType(), *r.GetNestedBlockType(), r.GetAttributeName())
+		return resources, moduleEvaluator.Evaluator, diags
 	}
 
-	resources, diags := getSimpleResourcesWithAttributes(config.Module, r.GetResourceType(), r.GetAttributeName(), ctx)
+	resources, diags := moduleEvaluator.getSimpleResourcesWithAttributes(r.GetResourceType(), r.GetAttributeName())
 
-	return ctx, resources, diags
-}
-
-func getResourcesOfResourceTypeIncludingSpecifiedAttribute(module *terraform.Module, attributeName string, ctx *terraform.Evaluator) (*hclext.BodyContent, hcl.Diagnostics) {
-	resources, diags := module.PartialContent(&hclext.BodySchema{
-		Blocks: []hclext.BlockSchema{
-			{
-				Type:       "resource",
-				LabelNames: []string{"type", "name"},
-				Body: &hclext.BodySchema{
-					Attributes: []hclext.AttributeSchema{
-						{
-							Name:     attributeName,
-							Required: false,
-						},
-					},
-				},
-			},
-		},
-	}, ctx)
-
-	return resources, diags
-}
-
-func getResourcesOfResourceTypeIncludingBlocksWithSpecifiedAttribute(module *terraform.Module, nestedBlockType string, attributeName string, ctx *terraform.Evaluator) (*hclext.BodyContent, hcl.Diagnostics) {
-	resources, diags := module.PartialContent(&hclext.BodySchema{
-		Blocks: []hclext.BlockSchema{
-			{
-				Type:       "resource",
-				LabelNames: []string{"type", "name"},
-				Body: &hclext.BodySchema{
-					Blocks: []hclext.BlockSchema{
-						{
-							Type: nestedBlockType,
-							Body: &hclext.BodySchema{
-								Attributes: []hclext.AttributeSchema{
-									{
-										Name:     attributeName,
-										Required: false,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}, ctx)
-
-	return resources, diags
+	return resources, moduleEvaluator.Evaluator, diags
 }

--- a/attrvalue/module_evaluator.go
+++ b/attrvalue/module_evaluator.go
@@ -1,0 +1,175 @@
+package attrvalue
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/spf13/afero"
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint/terraform"
+	"github.com/terraform-linters/tflint/terraform/addrs"
+)
+
+var AppFs = afero.Afero{
+	Fs: afero.NewOsFs(),
+}
+
+type moduleEvaluator struct {
+	*terraform.Evaluator
+}
+
+func newModuleEvaluator(runner tflint.Runner) (*moduleEvaluator, hcl.Diagnostics) {
+	wd, _ := runner.GetOriginalwd()
+	loader, err := terraform.NewLoader(AppFs, wd)
+	if err != nil {
+		return nil, hcl.Diagnostics{{
+			Summary: err.Error(),
+		}}
+	}
+	config, diags := loader.LoadConfig(".", terraform.CallLocalModule)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	vvals, diags := terraform.VariableValues(config)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	return &moduleEvaluator{
+		Evaluator: &terraform.Evaluator{
+			Meta: &terraform.ContextMeta{
+				Env:                "",
+				OriginalWorkingDir: wd,
+			},
+			Config:         config,
+			VariableValues: vvals,
+			ModulePath:     addrs.RootModuleInstance,
+		},
+	}, nil
+}
+
+// getSimpleResourcesWithAttributes returns a slice of resources with the given resource type and the attribute if it exists.
+func (e *moduleEvaluator) getSimpleResourcesWithAttributes(resourceType string, attributeName string) ([]*hclext.Block, hcl.Diagnostics) {
+	resources, diags := e.getResourcesOfResourceTypeIncludingSpecifiedAttribute(attributeName)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	filteredResources := make([]*hclext.Block, 0, len(resources.Blocks))
+	for _, resource := range resources.Blocks {
+		if resource.Labels[0] != resourceType {
+			continue
+		}
+		filteredResources = append(filteredResources, resource)
+	}
+	return filteredResources, nil
+}
+
+// getSimpleAttrs returns a slice of attributes with the given attribute name from the resources of the given resource type.
+func (e *moduleEvaluator) getSimpleAttrs(resourceType string, attributeName string) ([]*hclext.Attribute, hcl.Diagnostics) {
+	resources, diags := e.getResourcesOfResourceTypeIncludingSpecifiedAttribute(attributeName)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	attrs := make([]*hclext.Attribute, 0, len(resources.Blocks))
+	for _, resource := range resources.Blocks {
+		if resource.Labels[0] != resourceType {
+			continue
+		}
+		if attribute := e.getAttrFromBlock(resource, attributeName); attribute != nil {
+			attrs = append(attrs, attribute)
+		}
+	}
+	return attrs, nil
+}
+
+// getNestedResourcesWithBlockAttributes returns a slice of resources with the given resource type and the attribute if it exists.
+func (e *moduleEvaluator) getNestedResourcesWithBlockAttributes(resourceType, nestedBlockType, attributeName string) ([]*hclext.Block, hcl.Diagnostics) {
+	resources, diags := e.getResourcesOfResourceTypeIncludingBlocksWithSpecifiedAttribute(nestedBlockType, attributeName)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	filteredResources := make([]*hclext.Block, 0, len(resources.Blocks))
+	for _, resource := range resources.Blocks {
+		if resource.Labels[0] != resourceType {
+			continue
+		}
+		filteredResources = append(filteredResources, resource)
+	}
+	return filteredResources, nil
+}
+
+// getNestedBlockAttrs returns a slice of attributes with the given attribute name from the nested blocks of the given resource type.
+func (e *moduleEvaluator) getNestedBlockAttrs(resourceType, nestedBlockType, attributeName string) ([]*hclext.Attribute, hcl.Diagnostics) {
+	resources, diags := e.getResourcesOfResourceTypeIncludingBlocksWithSpecifiedAttribute(nestedBlockType, attributeName)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	attrs := make([]*hclext.Attribute, 0, len(resources.Blocks))
+	for _, resource := range resources.Blocks {
+		if resource.Labels[0] != resourceType {
+			continue
+		}
+		for _, block := range resource.Body.Blocks {
+			if attr := e.getAttrFromBlock(block, attributeName); attr != nil {
+				attrs = append(attrs, attr)
+			}
+		}
+	}
+	return attrs, nil
+}
+
+// getAttrFromBlock returns the attribute with the given attribute name from the block.
+func (e *moduleEvaluator) getAttrFromBlock(block *hclext.Block, attributeName string) *hclext.Attribute {
+	attribute, exists := block.Body.Attributes[attributeName]
+	if !exists {
+		return nil
+	}
+	return attribute
+}
+
+func (e *moduleEvaluator) getResourcesOfResourceTypeIncludingSpecifiedAttribute(attributeName string) (*hclext.BodyContent, hcl.Diagnostics) {
+	resources, diags := e.Config.Module.PartialContent(&hclext.BodySchema{
+		Blocks: []hclext.BlockSchema{
+			{
+				Type:       "resource",
+				LabelNames: []string{"type", "name"},
+				Body: &hclext.BodySchema{
+					Attributes: []hclext.AttributeSchema{
+						{
+							Name:     attributeName,
+							Required: false,
+						},
+					},
+				},
+			},
+		},
+	}, e.Evaluator)
+
+	return resources, diags
+}
+
+func (e *moduleEvaluator) getResourcesOfResourceTypeIncludingBlocksWithSpecifiedAttribute(nestedBlockType string, attributeName string) (*hclext.BodyContent, hcl.Diagnostics) {
+	resources, diags := e.Config.Module.PartialContent(&hclext.BodySchema{
+		Blocks: []hclext.BlockSchema{
+			{
+				Type:       "resource",
+				LabelNames: []string{"type", "name"},
+				Body: &hclext.BodySchema{
+					Blocks: []hclext.BlockSchema{
+						{
+							Type: nestedBlockType,
+							Body: &hclext.BodySchema{
+								Attributes: []hclext.AttributeSchema{
+									{
+										Name:     attributeName,
+										Required: false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, e.Evaluator)
+
+	return resources, diags
+}

--- a/attrvalue/nested_block_value_test.go
+++ b/attrvalue/nested_block_value_test.go
@@ -4,10 +4,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/Azure/tflint-ruleset-avm/attrvalue"
 	"github.com/prashantv/gostub"
 	"github.com/spf13/afero"
-
-	"github.com/Azure/tflint-ruleset-avm/attrvalue"
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )

--- a/attrvalue/set_value.go
+++ b/attrvalue/set_value.go
@@ -14,7 +14,7 @@ import (
 // It is not concerned with the order of the numbers in the list.
 type SetRule[T cmp.Ordered] struct {
 	tflint.DefaultRule // Embed the default rule to reuse its implementation
-	baseValue
+	*baseValue
 	expectedValues [][]T // e.g. [][int{1, 2, 3}]
 	ruleName       string
 }

--- a/attrvalue/set_value_test.go
+++ b/attrvalue/set_value_test.go
@@ -3,9 +3,8 @@ package attrvalue_test
 import (
 	"testing"
 
-	"github.com/prashantv/gostub"
-
 	"github.com/Azure/tflint-ruleset-avm/attrvalue"
+	"github.com/prashantv/gostub"
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )

--- a/attrvalue/simple_value.go
+++ b/attrvalue/simple_value.go
@@ -14,7 +14,7 @@ import (
 // It can be used to check string, number, and bool attributes.
 type SimpleRule[T any] struct {
 	tflint.DefaultRule // Embed the default rule to reuse its implementation
-	baseValue
+	*baseValue
 	expectedValues []T // e.g. []string{"ZRS"}
 	mustExist      bool
 	ruleName       string

--- a/attrvalue/simple_value_test.go
+++ b/attrvalue/simple_value_test.go
@@ -3,9 +3,8 @@ package attrvalue_test
 import (
 	"testing"
 
-	"github.com/prashantv/gostub"
-
 	"github.com/Azure/tflint-ruleset-avm/attrvalue"
+	"github.com/prashantv/gostub"
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )

--- a/attrvalue/unknown_value.go
+++ b/attrvalue/unknown_value.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
-
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -12,7 +11,7 @@ import (
 // UnknownValueRule checks whether an attribute value is null or part of a variable with no default value.
 type UnknownValueRule struct {
 	tflint.DefaultRule // Embed the default rule to reuse its implementation
-	baseValue
+	*baseValue
 	ruleName string
 }
 

--- a/attrvalue/unknown_value_test.go
+++ b/attrvalue/unknown_value_test.go
@@ -3,9 +3,8 @@ package attrvalue_test
 import (
 	"testing"
 
-	"github.com/prashantv/gostub"
-
 	"github.com/Azure/tflint-ruleset-avm/attrvalue"
+	"github.com/prashantv/gostub"
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )

--- a/rules/dummy_runner.go
+++ b/rules/dummy_runner.go
@@ -1,0 +1,26 @@
+package rules
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+var _ tflint.Runner = &issueCollectDummyRunner{}
+
+type issueCollectDummyRunner struct {
+	tflint.Runner
+}
+
+func newIssueCollectDummyRunner(runner tflint.Runner) *issueCollectDummyRunner {
+	return &issueCollectDummyRunner{
+		Runner: runner,
+	}
+}
+
+func (r *issueCollectDummyRunner) EmitIssue(rule tflint.Rule, message string, issueRange hcl.Range) error {
+	return nil
+}
+
+func (r *issueCollectDummyRunner) EmitIssueWithFix(rule tflint.Rule, message string, issueRange hcl.Range, fixFunc func(f tflint.Fixer) error) error {
+	return nil
+}

--- a/rules/dummy_runner.go
+++ b/rules/dummy_runner.go
@@ -5,22 +5,23 @@ import (
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
 
-var _ tflint.Runner = &issueCollectDummyRunner{}
+var _ tflint.Runner = &dummyRunner{}
 
-type issueCollectDummyRunner struct {
+// dummyRunner is used in `valid_template_interpolation` rule to run other WAF rules, but we just want to probe potential interpolation errors, not emit issues, so we wrap the actual runner with this dummy runner, swallow all emitted issues.
+type dummyRunner struct {
 	tflint.Runner
 }
 
-func newIssueCollectDummyRunner(runner tflint.Runner) *issueCollectDummyRunner {
-	return &issueCollectDummyRunner{
+func newIssueCollectDummyRunner(runner tflint.Runner) *dummyRunner {
+	return &dummyRunner{
 		Runner: runner,
 	}
 }
 
-func (r *issueCollectDummyRunner) EmitIssue(rule tflint.Rule, message string, issueRange hcl.Range) error {
+func (r *dummyRunner) EmitIssue(rule tflint.Rule, message string, issueRange hcl.Range) error {
 	return nil
 }
 
-func (r *issueCollectDummyRunner) EmitIssueWithFix(rule tflint.Rule, message string, issueRange hcl.Range, fixFunc func(f tflint.Fixer) error) error {
+func (r *dummyRunner) EmitIssueWithFix(rule tflint.Rule, message string, issueRange hcl.Range, fixFunc func(f tflint.Fixer) error) error {
 	return nil
 }

--- a/rules/rule_register.go
+++ b/rules/rule_register.go
@@ -29,6 +29,7 @@ var Rules = func() []tflint.Rule {
 				"0.2.999",
 				"1.0.0",
 			}),
+			NewValidTemplateInterpolationRule(),
 		},
 		waf.GetRules(),
 		interfaces.Rules,

--- a/rules/valid_template_interpolation.go
+++ b/rules/valid_template_interpolation.go
@@ -1,0 +1,48 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/Azure/tflint-ruleset-avm/attrvalue"
+	"github.com/Azure/tflint-ruleset-avm/waf"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+var TemplateInterpolationErrorRegex = regexp.MustCompile("Invalid template interpolation value;")
+var _ tflint.Rule = new(ValidTemplateInterpolationRule)
+
+type ValidTemplateInterpolationRule struct {
+	tflint.DefaultRule
+}
+
+func (v *ValidTemplateInterpolationRule) Name() string {
+	return "valid_template_interpolation"
+}
+
+func (v *ValidTemplateInterpolationRule) Enabled() bool {
+	return true
+}
+
+func (v *ValidTemplateInterpolationRule) Severity() tflint.Severity {
+	return tflint.WARNING
+}
+
+func (v *ValidTemplateInterpolationRule) Check(r tflint.Runner) error {
+	dummyRunner := newIssueCollectDummyRunner(r)
+	for _, wafRule := range waf.GetRules() {
+		p, ok := wafRule.(attrvalue.PartialContentEvaluationRule)
+		if !ok {
+			continue
+		}
+		p.EnableFailOnEvaluationError()
+		if err := wafRule.Check(dummyRunner); err != nil && TemplateInterpolationErrorRegex.MatchString(err.Error()) {
+			return fmt.Errorf("cannot evaluate template interpolation, usually due to null reference error or other issues: %+v", err)
+		}
+	}
+	return nil
+}
+
+func NewValidTemplateInterpolationRule() *ValidTemplateInterpolationRule {
+	return new(ValidTemplateInterpolationRule)
+}

--- a/rules/valid_template_interpolation_test.go
+++ b/rules/valid_template_interpolation_test.go
@@ -1,0 +1,35 @@
+package rules_test
+
+import (
+	"github.com/Azure/tflint-ruleset-avm/attrvalue"
+	"github.com/Azure/tflint-ruleset-avm/rules"
+	"github.com/prashantv/gostub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+	"testing"
+)
+
+func TestPartialContentEvaluationFailureShouldFailValidTerraformConfigRule(t *testing.T) {
+	sut := rules.NewValidTemplateInterpolationRule()
+	content := `
+    variable "null" {
+	  type    = string
+      default = null
+    }
+    locals {
+      name = "${var.null}-rg"
+    }
+	resource "azurerm_resource_group" "example" {
+	  location = "eastus"
+	  name     = local.name
+	}`
+
+	filename := "main.tf"
+	runner := helper.TestRunner(t, map[string]string{filename: content})
+	stub := gostub.Stub(&attrvalue.AppFs, mockFs(content))
+	defer stub.Reset()
+	err := sut.Check(runner)
+	require.NotNil(t, err)
+	assert.Regexp(t, rules.TemplateInterpolationErrorRegex, err.Error())
+}

--- a/waf/azurerm_cosmosdb_account_test.go
+++ b/waf/azurerm_cosmosdb_account_test.go
@@ -3,10 +3,9 @@ package waf_test
 import (
 	"testing"
 
-	"github.com/prashantv/gostub"
-
 	"github.com/Azure/tflint-ruleset-avm/attrvalue"
 	"github.com/Azure/tflint-ruleset-avm/waf"
+	"github.com/prashantv/gostub"
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )

--- a/waf/azurerm_mysql_flexible_server_test.go
+++ b/waf/azurerm_mysql_flexible_server_test.go
@@ -3,10 +3,9 @@ package waf_test
 import (
 	"testing"
 
-	"github.com/prashantv/gostub"
-
 	"github.com/Azure/tflint-ruleset-avm/attrvalue"
 	"github.com/Azure/tflint-ruleset-avm/waf"
+	"github.com/prashantv/gostub"
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )

--- a/waf/azurerm_postgresql_flexible_server_test.go
+++ b/waf/azurerm_postgresql_flexible_server_test.go
@@ -3,10 +3,9 @@ package waf_test
 import (
 	"testing"
 
-	"github.com/prashantv/gostub"
-
 	"github.com/Azure/tflint-ruleset-avm/attrvalue"
 	"github.com/Azure/tflint-ruleset-avm/waf"
+	"github.com/prashantv/gostub"
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )

--- a/waf/azurerm_virtual_machine_test.go
+++ b/waf/azurerm_virtual_machine_test.go
@@ -1,0 +1,37 @@
+package waf_test
+
+import (
+	"testing"
+
+	"github.com/Azure/tflint-ruleset-avm/attrvalue"
+	"github.com/Azure/tflint-ruleset-avm/waf"
+	"github.com/prashantv/gostub"
+	"github.com/stretchr/testify/assert"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func TestPartialContentEvaluationFailureShouldNotFailWafRule(t *testing.T) {
+	var w waf.WafRules
+	sut := w.AzurermLegacyVirtualMachineNotAllowed()
+	content := `
+    variable "null" {
+	  type    = string
+      default = null
+    }
+    locals {
+      name = "${var.null}-rg"
+    }
+	resource "azurerm_resource_group" "example" {
+	  location = "eastus"
+	  name     = local.name
+	}`
+
+	filename := "main.tf"
+	runner := helper.TestRunner(t, map[string]string{filename: content})
+	stub := gostub.Stub(&attrvalue.AppFs, mockFs(content))
+	defer stub.Reset()
+	if err := sut.Check(runner); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	assert.Empty(t, runner.Issues)
+}


### PR DESCRIPTION
The WAF rules would try to evaluate the whole modules, but such expressions would result in quite confusing error messages:

```hcl
variable "null" {
  default = null
}

locals {
  name = "${var.null}-rg"
}

resource "azurerm_resource_group" "this" {
  name     = local.name
  location = "eastus"
}
```

When WAF rules were trying to evaluate `azurerm_resource_group.this` block, it would fail with `Invalid template interpolation value;`, that's because `var.null`'s default value is `null`, and caused a template interpolation error. This error is as expected, but the problem is, when a rule named `azurerm_mysql_flexible_server` or something like that emitted the issue, the user could be confused since they haven't declared such resource in their Terraform config files.

This pr introduced a new rule `valid_template_interpolation`, which is an aggregation of all WAF rules, once one of them failed due to template interpolation error, then this new rule would throw the error. Then WAF rules would swallow the interpolation error. 