### PR TITLE
feat: add azapi/azurerm provider contraints

### DIFF
--- a/integration/optional-defaults-incorrect/terraform.tf
+++ b/integration/optional-defaults-incorrect/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.97.0, < 4.0.0"
+      version = "~> 4.0"
     }
     modtm = {
       source  = "Azure/modtm"

--- a/integration/optional-defaults/terraform.tf
+++ b/integration/optional-defaults/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.97.0, < 4.0.0"
+      version = "~> 4.0"
     }
     modtm = {
       source  = "Azure/modtm"

--- a/integration/simplevaluerule-null-value/terraform.tf
+++ b/integration/simplevaluerule-null-value/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.97.0, < 4.0.0"
+      version = "~> 4.0"
     }
     modtm = {
       source  = "Azure/modtm"

--- a/integration/unknownrule-null-incorrect/terraform.tf
+++ b/integration/unknownrule-null-incorrect/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.97.0, < 4.0.0"
+      version = "~> 4.0"
     }
     modtm = {
       source  = "Azure/modtm"

--- a/integration/unknownrule-null/terraform.tf
+++ b/integration/unknownrule-null/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.97.0, < 4.0.0"
+      version = "~> 4.0"
     }
     modtm = {
       source  = "Azure/modtm"

--- a/rules/provider_minimum_major_version.go
+++ b/rules/provider_minimum_major_version.go
@@ -18,14 +18,16 @@ type ProviderVersionRule struct {
 	ProviderSource               string
 	RecommendedVersionConstraint string
 	VersionsShouldFailed         []string
+	MustExist                    bool
 }
 
-func NewProviderVersionRule(providerName, providerSource, recommendedVersion string, versionsShouldFailed []string) *ProviderVersionRule {
+func NewProviderVersionRule(providerName, providerSource, recommendedVersion string, versionsShouldFailed []string, mustExist bool) *ProviderVersionRule {
 	return &ProviderVersionRule{
 		ProviderName:                 providerName,
 		ProviderSource:               providerSource,
 		RecommendedVersionConstraint: recommendedVersion,
 		VersionsShouldFailed:         versionsShouldFailed,
+		MustExist:                    mustExist,
 	}
 }
 
@@ -115,7 +117,7 @@ func (m *ProviderVersionRule) Check(r tflint.Runner) error {
 	if !requiredProviderFound {
 		return nil
 	}
-	if !providerFound {
+	if !providerFound && m.MustExist {
 		return r.EmitIssue(m, fmt.Sprintf("`%s` provider should be declared in the `required_providers` block", m.ProviderName), content.Blocks[0].DefRange)
 	}
 	return nil

--- a/rules/provider_minimum_major_version_test.go
+++ b/rules/provider_minimum_major_version_test.go
@@ -25,7 +25,7 @@ func TestModtmProviderVersionRule(t *testing.T) {
 			rule: rules.NewProviderVersionRule("modtm", "Azure/modtm", "~> 0.3", []string{
 				"0.2.99",
 				"1.0.0",
-			}),
+			}, true),
 			expected: helper.Issues{},
 		},
 		{
@@ -35,7 +35,7 @@ func TestModtmProviderVersionRule(t *testing.T) {
 			rule: rules.NewProviderVersionRule("modtm", "Azure/modtm", "~> 0.3", []string{
 				"0.2.99",
 				"1.0.0",
-			}),
+			}, true),
 			expected: helper.Issues{},
 		},
 		{
@@ -51,16 +51,32 @@ func TestModtmProviderVersionRule(t *testing.T) {
 			rule: rules.NewProviderVersionRule("modtm", "Azure/modtm", "~> 0.3", []string{
 				"0.2.999",
 				"1.0.0",
-			}),
+			}, true),
 			expected: helper.Issues{
 				{
 					Rule: rules.NewProviderVersionRule("modtm", "Azure/modtm", "~> 0.3", []string{
 						"0.2.999",
 						"1.0.0",
-					}),
+					}, true),
 					Message: "`modtm` provider should be declared in the `required_providers` block",
 				},
 			},
+		},
+		{
+			desc: "no modtm defined in required_providers but not mandatory - ok",
+			config: `terraform{
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "3.111.0"
+    }
+  }
+}`,
+			rule: rules.NewProviderVersionRule("modtm", "Azure/modtm", "~> 0.3", []string{
+				"0.2.999",
+				"1.0.0",
+			}, false),
+			expected: helper.Issues{},
 		},
 		{
 			desc: "modtm defined in required_providers with incorrect source emit issue",
@@ -75,13 +91,13 @@ func TestModtmProviderVersionRule(t *testing.T) {
 			rule: rules.NewProviderVersionRule("modtm", "Azure/modtm", "~> 0.3", []string{
 				"0.2.999",
 				"1.0.0",
-			}),
+			}, true),
 			expected: helper.Issues{
 				{
 					Rule: rules.NewProviderVersionRule("modtm", "Azure/modtm", "~> 0.3", []string{
 						"0.2.999",
 						"1.0.0",
-					}),
+					}, true),
 					Message: "provider `modtm`'s source should be Azure/modtm, got notAzure/modtm",
 				},
 			},
@@ -99,13 +115,13 @@ func TestModtmProviderVersionRule(t *testing.T) {
 			rule: rules.NewProviderVersionRule("modtm", "Azure/modtm", "~> 0.3", []string{
 				"0.2.999",
 				"1.0.0",
-			}),
+			}, true),
 			expected: helper.Issues{
 				{
 					Rule: rules.NewProviderVersionRule("modtm", "Azure/modtm", "~> 0.3", []string{
 						"0.2.999",
 						"1.0.0",
-					}),
+					}, true),
 					Message: "this module should not support provider `modtm` version 0.2.999, recommended version constraint: ~> 0.3",
 				},
 			},
@@ -123,13 +139,13 @@ func TestModtmProviderVersionRule(t *testing.T) {
 			rule: rules.NewProviderVersionRule("modtm", "Azure/modtm", "~> 0.3", []string{
 				"0.2.999",
 				"1.0.0",
-			}),
+			}, true),
 			expected: helper.Issues{
 				{
 					Rule: rules.NewProviderVersionRule("modtm", "Azure/modtm", "~> 0.3", []string{
 						"0.2.999",
 						"1.0.0",
-					}),
+					}, true),
 					Message: "this module should not support provider `modtm` version 1.0.0, recommended version constraint: ~> 0.3",
 				},
 			},
@@ -147,7 +163,7 @@ func TestModtmProviderVersionRule(t *testing.T) {
 			rule: rules.NewProviderVersionRule("modtm", "Azure/modtm", "~> 0.3", []string{
 				"0.2.999",
 				"1.0.0",
-			}),
+			}, true),
 			expected: helper.Issues{},
 		},
 		{
@@ -163,7 +179,7 @@ func TestModtmProviderVersionRule(t *testing.T) {
 			rule: rules.NewProviderVersionRule("modtm", "Azure/modtm", "~> 0.3", []string{
 				"0.2.999",
 				"1.0.0",
-			}),
+			}, true),
 			expected: helper.Issues{},
 		},
 	}

--- a/rules/rule_register.go
+++ b/rules/rule_register.go
@@ -33,7 +33,7 @@ var Rules = func() []tflint.Rule {
 				"1.9.999",
 				"3.0.0",
 			}, false),
-			NewProviderVersionRule("azapi", "hashicorp/azurerm", "~> 4.0", []string{
+			NewProviderVersionRule("azurerm", "hashicorp/azurerm", "~> 4.0", []string{
 				"3.199.999",
 				"5.0.0",
 			}, false),

--- a/rules/rule_register.go
+++ b/rules/rule_register.go
@@ -28,7 +28,15 @@ var Rules = func() []tflint.Rule {
 			NewProviderVersionRule("modtm", "Azure/modtm", "~> 0.3", []string{
 				"0.2.999",
 				"1.0.0",
-			}),
+			}, true),
+			NewProviderVersionRule("azapi", "Azure/azapi", "~> 2.0", []string{
+				"1.9.999",
+				"3.0.0",
+			}, false),
+			NewProviderVersionRule("azapi", "hashicorp/azurerm", "~> 4.0", []string{
+				"3.199.999",
+				"5.0.0",
+			}, false),
 			NewValidTemplateInterpolationRule(),
 		},
 		waf.GetRules(),


### PR DESCRIPTION
Constrains azapi and azurerm to the specified versions: https://azure.github.io/Azure-Verified-Modules/specs/tf/res/#id-tffr3---category-providers---permitted-versions

Makes provider check optional via a flag