### PR TITLE
add new lint rule, raise warning for preview api in azapi blocks

### DIFF
--- a/rules/azapi_no_preview_version.go
+++ b/rules/azapi_no_preview_version.go
@@ -1,0 +1,89 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/zclconf/go-cty/cty"
+)
+
+var _ tflint.Rule = new(AzApiNoPreviewVersionRule)
+
+type AzApiNoPreviewVersionRule struct {
+	tflint.DefaultRule
+}
+
+func NewAzApiNoPreviewVersionRule() *AzApiNoPreviewVersionRule {
+	return new(AzApiNoPreviewVersionRule)
+}
+
+func (a *AzApiNoPreviewVersionRule) Name() string {
+	return "azapi_no_preview_version_sfr1"
+}
+
+func (a *AzApiNoPreviewVersionRule) Link() string {
+	return "https://azure.github.io/Azure-Verified-Modules/spec/SFR1/"
+}
+
+func (a *AzApiNoPreviewVersionRule) Enabled() bool {
+	return false
+}
+
+func (a *AzApiNoPreviewVersionRule) Severity() tflint.Severity {
+	return tflint.WARNING
+}
+
+func (a *AzApiNoPreviewVersionRule) Check(r tflint.Runner) error {
+	types := []string{"data", "resource", "ephemeral"}
+	for _, t := range types {
+		var bodySchema = &hclext.BodySchema{
+			Blocks: []hclext.BlockSchema{
+				{
+					Type:       t,
+					LabelNames: []string{"type", "name"},
+					Body: &hclext.BodySchema{
+						Mode: 0,
+						Attributes: []hclext.AttributeSchema{
+							{
+								Name:     "type",
+								Required: false,
+							},
+						},
+					},
+				},
+			},
+		}
+		body, err := r.GetModuleContent(bodySchema, nil)
+		if err != nil {
+			return err
+		}
+		for _, block := range body.Blocks {
+			if !strings.HasPrefix(block.Labels[0], "azapi_") {
+				continue
+			}
+			typeAttribute, ok := block.Body.Attributes["type"]
+			if !ok {
+				continue
+			}
+			var typeValue string
+			if err = r.EvaluateExpr(typeAttribute.Expr, &typeValue, &tflint.EvaluateExprOption{
+				WantType: &cty.String,
+			}); err != nil {
+				return err
+			}
+			if !strings.HasSuffix(strings.ToLower(typeValue), "-preview") {
+				continue
+			}
+			if err = r.EmitIssue(
+				a,
+				fmt.Sprintf("Resource type `%s` is using a preview API version, which is not recommended.", typeValue),
+				typeAttribute.Range,
+			); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/rules/azapi_no_preview_version_test.go
+++ b/rules/azapi_no_preview_version_test.go
@@ -1,0 +1,327 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/Azure/tflint-ruleset-avm/rules"
+	"github.com/stretchr/testify/require"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func TestAzApiNoPreviewVersion(t *testing.T) {
+	cases := []struct {
+		desc   string
+		config string
+		issues helper.Issues
+	}{
+		// azapi_resource tests
+		{
+			desc: "azapi_resource with non-preview API version, ok",
+			config: `resource "azapi_resource" "test" {
+  type     = "Microsoft.Storage/storageAccounts@2023-01-01"
+  name     = "test"
+  location = "westeurope"
+  parent_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test"
+}`,
+			issues: helper.Issues{},
+		},
+		{
+			desc: "azapi_resource with preview API version, not ok",
+			config: `resource "azapi_resource" "test" {
+  type     = "Microsoft.Storage/storageAccounts@2023-01-01-preview"
+  name     = "test"
+  location = "westeurope"
+  parent_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test"
+}`,
+			issues: helper.Issues{
+				{
+					Rule:    &rules.AzApiNoPreviewVersionRule{},
+					Message: "Resource type `Microsoft.Storage/storageAccounts@2023-01-01-preview` is using a preview API version, which is not recommended.",
+				},
+			},
+		},
+		// azapi_update_resource tests
+		{
+			desc: "azapi_update_resource with non-preview API version, ok",
+			config: `resource "azapi_update_resource" "test" {
+  type      = "Microsoft.Storage/storageAccounts@2023-01-01"
+  resource_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test/providers/Microsoft.Storage/storageAccounts/test"
+}`,
+			issues: helper.Issues{},
+		},
+		{
+			desc: "azapi_update_resource with preview API version, not ok",
+			config: `resource "azapi_update_resource" "test" {
+  type      = "Microsoft.Storage/storageAccounts@2023-01-01-preview"
+  resource_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test/providers/Microsoft.Storage/storageAccounts/test"
+}`,
+			issues: helper.Issues{
+				{
+					Rule:    &rules.AzApiNoPreviewVersionRule{},
+					Message: "Resource type `Microsoft.Storage/storageAccounts@2023-01-01-preview` is using a preview API version, which is not recommended.",
+				},
+			},
+		},
+		// azapi_resource_action tests
+		{
+			desc: "azapi_resource_action with non-preview API version, ok",
+			config: `resource "azapi_resource_action" "test" {
+  type        = "Microsoft.Storage/storageAccounts@2023-01-01"
+  resource_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test/providers/Microsoft.Storage/storageAccounts/test"
+  action      = "listKeys"
+}`,
+			issues: helper.Issues{},
+		},
+		{
+			desc: "azapi_resource_action with preview API version, not ok",
+			config: `resource "azapi_resource_action" "test" {
+  type        = "Microsoft.Storage/storageAccounts@2023-01-01-preview"
+  resource_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test/providers/Microsoft.Storage/storageAccounts/test"
+  action      = "listKeys"
+}`,
+			issues: helper.Issues{
+				{
+					Rule:    &rules.AzApiNoPreviewVersionRule{},
+					Message: "Resource type `Microsoft.Storage/storageAccounts@2023-01-01-preview` is using a preview API version, which is not recommended.",
+				},
+			},
+		},
+		// azapi_data_plane_resource tests
+		{
+			desc: "azapi_data_plane_resource with non-preview API version, ok",
+			config: `resource "azapi_data_plane_resource" "test" {
+  type      = "Microsoft.Storage/storageAccounts@2023-01-01"
+  name      = "test"
+  parent_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test"
+}`,
+			issues: helper.Issues{},
+		},
+		{
+			desc: "azapi_data_plane_resource with preview API version, not ok",
+			config: `resource "azapi_data_plane_resource" "test" {
+  type      = "Microsoft.Storage/storageAccounts@2023-01-01-preview"
+  name      = "test"
+  parent_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test"
+}`,
+			issues: helper.Issues{
+				{
+					Rule:    &rules.AzApiNoPreviewVersionRule{},
+					Message: "Resource type `Microsoft.Storage/storageAccounts@2023-01-01-preview` is using a preview API version, which is not recommended.",
+				},
+			},
+		},
+		// Data source tests
+		{
+			desc: "azapi_resource data source with non-preview API version, ok",
+			config: `data "azapi_resource" "test" {
+  type      = "Microsoft.Storage/storageAccounts@2023-01-01"
+  name      = "test"
+  parent_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test"
+}`,
+			issues: helper.Issues{},
+		},
+		{
+			desc: "azapi_resource data source with preview API version, not ok",
+			config: `data "azapi_resource" "test" {
+  type      = "Microsoft.Storage/storageAccounts@2023-01-01-preview"
+  name      = "test"
+  parent_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test"
+}`,
+			issues: helper.Issues{
+				{
+					Rule:    &rules.AzApiNoPreviewVersionRule{},
+					Message: "Resource type `Microsoft.Storage/storageAccounts@2023-01-01-preview` is using a preview API version, which is not recommended.",
+				},
+			},
+		},
+		{
+			desc: "azapi_resource_action data source with non-preview API version, ok",
+			config: `data "azapi_resource_action" "test" {
+  type        = "Microsoft.Storage/storageAccounts@2023-01-01"
+  resource_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test/providers/Microsoft.Storage/storageAccounts/test"
+  action      = "listKeys"
+}`,
+			issues: helper.Issues{},
+		},
+		{
+			desc: "azapi_resource_action data source with preview API version, not ok",
+			config: `data "azapi_resource_action" "test" {
+  type        = "Microsoft.Storage/storageAccounts@2023-01-01-preview"
+  resource_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test/providers/Microsoft.Storage/storageAccounts/test"
+  action      = "listKeys"
+}`,
+			issues: helper.Issues{
+				{
+					Rule:    &rules.AzApiNoPreviewVersionRule{},
+					Message: "Resource type `Microsoft.Storage/storageAccounts@2023-01-01-preview` is using a preview API version, which is not recommended.",
+				},
+			},
+		},
+		{
+			desc: "azapi_resource_list data source with non-preview API version, ok",
+			config: `data "azapi_resource_list" "test" {
+  type      = "Microsoft.Storage/storageAccounts@2023-01-01"
+  parent_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test"
+}`,
+			issues: helper.Issues{},
+		},
+		{
+			desc: "azapi_resource_list data source with preview API version, not ok",
+			config: `data "azapi_resource_list" "test" {
+  type      = "Microsoft.Storage/storageAccounts@2023-01-01-preview"
+  parent_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test"
+}`,
+			issues: helper.Issues{
+				{
+					Rule:    &rules.AzApiNoPreviewVersionRule{},
+					Message: "Resource type `Microsoft.Storage/storageAccounts@2023-01-01-preview` is using a preview API version, which is not recommended.",
+				},
+			},
+		},
+		// Ephemeral tests
+		{
+			desc: "azapi_resource ephemeral with non-preview API version, ok",
+			config: `ephemeral "azapi_resource" "test" {
+  type      = "Microsoft.Storage/storageAccounts@2023-01-01"
+  name      = "test"
+  parent_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test"
+}`,
+			issues: helper.Issues{},
+		},
+		{
+			desc: "azapi_resource ephemeral with preview API version, not ok",
+			config: `ephemeral "azapi_resource" "test" {
+  type      = "Microsoft.Storage/storageAccounts@2023-01-01-preview"
+  name      = "test"
+  parent_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test"
+}`,
+			issues: helper.Issues{
+				{
+					Rule:    &rules.AzApiNoPreviewVersionRule{},
+					Message: "Resource type `Microsoft.Storage/storageAccounts@2023-01-01-preview` is using a preview API version, which is not recommended.",
+				},
+			},
+		},
+		{
+			desc: "azapi_resource_action ephemeral with non-preview API version, ok",
+			config: `ephemeral "azapi_resource_action" "test" {
+  type        = "Microsoft.Storage/storageAccounts@2023-01-01"
+  resource_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test/providers/Microsoft.Storage/storageAccounts/test"
+  action      = "listKeys"
+}`,
+			issues: helper.Issues{},
+		},
+		{
+			desc: "azapi_resource_action ephemeral with preview API version, not ok",
+			config: `ephemeral "azapi_resource_action" "test" {
+  type        = "Microsoft.Storage/storageAccounts@2023-01-01-preview"
+  resource_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test/providers/Microsoft.Storage/storageAccounts/test"
+  action      = "listKeys"
+}`,
+			issues: helper.Issues{
+				{
+					Rule:    &rules.AzApiNoPreviewVersionRule{},
+					Message: "Resource type `Microsoft.Storage/storageAccounts@2023-01-01-preview` is using a preview API version, which is not recommended.",
+				},
+			},
+		},
+		// Edge cases and ignored scenarios
+		{
+			desc: "non-azapi resource, should be ignored",
+			config: `resource "azurerm_storage_account" "test" {
+  name                     = "test"
+  resource_group_name      = "test"
+  location                 = "westeurope"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}`,
+			issues: helper.Issues{},
+		},
+		{
+			desc: "azapi_resource without type attribute, should be ignored",
+			config: `resource "azapi_resource" "test" {
+  name      = "test"
+  location  = "westeurope"
+  parent_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test"
+}`,
+			issues: helper.Issues{},
+		},
+		{
+			desc:   "azapi_client_config data source without type attribute, should be ignored",
+			config: `data "azapi_client_config" "current" {}`,
+			issues: helper.Issues{},
+		},
+		{
+			desc: "azapi_resource_id data source without type attribute, should be ignored",
+			config: `data "azapi_resource_id" "test" {
+  name      = "test"
+  parent_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test"
+  resource_type = "Microsoft.Storage/storageAccounts"
+}`,
+			issues: helper.Issues{},
+		},
+		// Multiple resources mixed scenario
+		{
+			desc: "multiple azapi resources with mixed API versions",
+			config: `resource "azapi_resource" "test1" {
+  type     = "Microsoft.Storage/storageAccounts@2023-01-01"
+  name     = "test1"
+  location = "westeurope"
+  parent_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test"
+}
+
+resource "azapi_resource" "test2" {
+  type     = "Microsoft.Compute/virtualMachines@2023-07-01-preview"
+  name     = "test2"
+  location = "westeurope"
+  parent_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test"
+}
+
+data "azapi_resource_action" "test3" {
+  type        = "Microsoft.Network/virtualNetworks@2023-02-01-preview"
+  resource_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test/providers/Microsoft.Network/virtualNetworks/test"
+  action      = "checkIPAddressAvailability"
+}`,
+			issues: helper.Issues{
+				{
+					Rule:    &rules.AzApiNoPreviewVersionRule{},
+					Message: "Resource type `Microsoft.Compute/virtualMachines@2023-07-01-preview` is using a preview API version, which is not recommended.",
+				},
+				{
+					Rule:    &rules.AzApiNoPreviewVersionRule{},
+					Message: "Resource type `Microsoft.Network/virtualNetworks@2023-02-01-preview` is using a preview API version, which is not recommended.",
+				},
+			},
+		},
+		// Different preview version formats
+		{
+			desc: "different preview version format variations, all should be detected",
+			config: `resource "azapi_resource" "test1" {
+  type = "Microsoft.Storage/storageAccounts@2023-01-01-PREVIEW"
+  name = "test1"
+  location = "westeurope"
+  parent_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test"
+}`,
+			issues: helper.Issues{
+				{
+					Rule:    &rules.AzApiNoPreviewVersionRule{},
+					Message: "Resource type `Microsoft.Storage/storageAccounts@2023-01-01-PREVIEW` is using a preview API version, which is not recommended.",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			rule := &rules.AzApiNoPreviewVersionRule{}
+			filename := "terraform.tf"
+
+			runner := helper.TestRunner(t, map[string]string{filename: tc.config})
+
+			require.NoError(t, rule.Check(runner))
+			helper.AssertIssuesWithoutRange(t, tc.issues, runner.Issues)
+		})
+	}
+}

--- a/rules/rule_register.go
+++ b/rules/rule_register.go
@@ -25,6 +25,7 @@ var Rules = func() []tflint.Rule {
 			NewTerraformDotTfRule(),
 			NewModuleSourceRule(),
 			NewNoDoubleQuotesInIgnoreChangesRule(),
+			NewAzApiNoPreviewVersionRule(),
 			NewProviderVersionRule("modtm", "Azure/modtm", "0.3.0", "~> 0.3", true),
 			NewProviderVersionRule("azapi", "Azure/azapi", "2.999.0", "~> 2.0", false),
 			NewProviderVersionRule("azurerm", "hashicorp/azurerm", "4.999.0", "~> 4.0", false),


### PR DESCRIPTION
According to [rule SFR1](https://azure.github.io/Azure-Verified-Modules/spec/SFR1/), the preview API version may be used in very rare scenario, so this pr added a warning on preview API version for all AzAPI blocks.