### PR TITLE
[Infra]: bump ubuntu pool to 24

### DIFF
--- a/.azdo/build-pipeline.yml
+++ b/.azdo/build-pipeline.yml
@@ -16,7 +16,7 @@ variables:
 stages:
   - stage: build
     pool:
-      name: pool-ubuntu-2004
+      name: pool-ubuntu-2404
     displayName: "Build tflint-ruleset-avm"
     jobs:
       - job: build
@@ -130,7 +130,7 @@ stages:
   - stage: github_release
     displayName: "Github Draft Release"
     pool:
-      name: pool-ubuntu-2004
+      name: pool-ubuntu-2404
     jobs:
       - job: release
         displayName: "Github Release"


### PR DESCRIPTION
Ubuntu 20 is out of support. We want to upgrade all projects previously using `pool-ubuntu-2004` to `pool-ubuntu-2404`