### PR TITLE
feat(interfaces): enforce required AzAPI variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ plugin "avm" {
 | deprecated_private_endpoints_interface | true | NOTICE | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#private-endpoints) |
 | deprecated_role_assignments_interface | true | NOTICE | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#role-assignments) |
 | diagnostic_settings | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#diagnostic-settings) |
+| ignore_body_changes | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/spec/TFFR8/](https://azure.github.io/Azure-Verified-Modules/spec/TFFR8/) |
 | location | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/r...](https://azure.github.io/Azure-Verified-Modules/specs/tf/res/#id-rmnfr2---category-inputs---parametervariable-naming) |
 | lock | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#resource-locks) |
 | managed_identities | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#managed-identities) |
 | no_entire_resource_output_tffr2 | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/r...](https://azure.github.io/Azure-Verified-Modules/specs/tf/res/#id-tffr2---category-outputs---additional-terraform-outputs) |
 | private_endpoints | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#private-endpoints) |
+| private_endpoints_manage_dns_zone_group | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/includes/i...](https://azure.github.io/Azure-Verified-Modules/includes/interfaces/tf/int.pe.schema.tf) |
 | provider_azapi_version_constraint | true | ERROR | - |
 | provider_azurerm_disallowed | true | ERROR | - |
 | provider_azurerm_version_constraint | true | ERROR | - |
@@ -52,6 +54,8 @@ plugin "avm" {
 | required_module_source_tffr1 | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/terr...](https://azure.github.io/Azure-Verified-Modules/specs/terraform/#id-tffr1---category-composition---cross-referencing-modules) |
 | required_module_source_tfnfr10 | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/terr...](https://azure.github.io/Azure-Verified-Modules/specs/terraform/#id-tfnfr10---category-code-style---no-double-quotes-in-ignore_changes) |
 | required_output_rmfr7 | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/shar...](https://azure.github.io/Azure-Verified-Modules/specs/shared/#id-rmfr7---category-outputs---minimum-required-outputs) |
+| resource_types | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/spec/TFFR6/](https://azure.github.io/Azure-Verified-Modules/spec/TFFR6/) |
+| retry | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/spec/TFFR7/](https://azure.github.io/Azure-Verified-Modules/spec/TFFR7/) |
 | role_assignments | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#role-assignments) |
 | tags | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#tags) |
 | terraform_count_index_usage | false | WARNING | - |
@@ -69,6 +73,7 @@ plugin "avm" {
 | terraform_variable_separate | false | NOTICE | [https://github.com/Azure/tflint-ruleset-avm/blob/main/doc...](https://github.com/Azure/tflint-ruleset-avm/blob/main/docs/basic/terraform_variable_separate.md) |
 | terraform_versions_file | false | NOTICE | - |
 | tfnfr26 | false | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/terr...](https://azure.github.io/Azure-Verified-Modules/specs/terraform/#id-tfnfr26---category-code-style---providers-must-be-declared-in-the-required_providers-block-in-terraformtf-and-must-have-a-constraint-on-minimum-and-maximum-major-version) |
+| timeouts | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/spec/TFFR7/](https://azure.github.io/Azure-Verified-Modules/spec/TFFR7/) |
 <!-- RULES:END -->
 
 See [`RULES.md`](./RULES.md) for the full rules reference (same content, kept in sync automatically).
@@ -86,7 +91,7 @@ To regenerate after adding, removing, or modifying rules, run:
 This script:
 
 1. Runs `go generate ./...`, which executes `cmd/rulesdoc` to refresh `RULES.md` from `rules.Rules`.
-2. Splices the rules table from `RULES.md` into the `<!-- RULES:START --> ... <!-- RULES:END -->` markers in `README.md`.
+2. Splices the rules table from `RULES.md` into the `<!-- RULES:START -->` / `<!-- RULES:END -->` markers in `README.md`.
 
 A GitHub Actions workflow (`.github/workflows/rules-docs-check.yml`) runs the same script on pull requests that touch rule sources and fails the build if `README.md` or `RULES.md` is out of date, so drift cannot land on `main`.
 

--- a/RULES.md
+++ b/RULES.md
@@ -14,11 +14,13 @@ This document lists all rules currently registered in this ruleset. The Enabled 
 | deprecated_private_endpoints_interface | true | NOTICE | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#private-endpoints) |
 | deprecated_role_assignments_interface | true | NOTICE | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#role-assignments) |
 | diagnostic_settings | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#diagnostic-settings) |
+| ignore_body_changes | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/spec/TFFR8/](https://azure.github.io/Azure-Verified-Modules/spec/TFFR8/) |
 | location | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/r...](https://azure.github.io/Azure-Verified-Modules/specs/tf/res/#id-rmnfr2---category-inputs---parametervariable-naming) |
 | lock | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#resource-locks) |
 | managed_identities | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#managed-identities) |
 | no_entire_resource_output_tffr2 | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/r...](https://azure.github.io/Azure-Verified-Modules/specs/tf/res/#id-tffr2---category-outputs---additional-terraform-outputs) |
 | private_endpoints | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#private-endpoints) |
+| private_endpoints_manage_dns_zone_group | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/includes/i...](https://azure.github.io/Azure-Verified-Modules/includes/interfaces/tf/int.pe.schema.tf) |
 | provider_azapi_version_constraint | true | ERROR | - |
 | provider_azurerm_disallowed | true | ERROR | - |
 | provider_azurerm_version_constraint | true | ERROR | - |
@@ -26,6 +28,8 @@ This document lists all rules currently registered in this ruleset. The Enabled 
 | required_module_source_tffr1 | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/terr...](https://azure.github.io/Azure-Verified-Modules/specs/terraform/#id-tffr1---category-composition---cross-referencing-modules) |
 | required_module_source_tfnfr10 | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/terr...](https://azure.github.io/Azure-Verified-Modules/specs/terraform/#id-tfnfr10---category-code-style---no-double-quotes-in-ignore_changes) |
 | required_output_rmfr7 | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/shar...](https://azure.github.io/Azure-Verified-Modules/specs/shared/#id-rmfr7---category-outputs---minimum-required-outputs) |
+| resource_types | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/spec/TFFR6/](https://azure.github.io/Azure-Verified-Modules/spec/TFFR6/) |
+| retry | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/spec/TFFR7/](https://azure.github.io/Azure-Verified-Modules/spec/TFFR7/) |
 | role_assignments | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#role-assignments) |
 | tags | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#tags) |
 | terraform_count_index_usage | false | WARNING | - |
@@ -43,3 +47,4 @@ This document lists all rules currently registered in this ruleset. The Enabled 
 | terraform_variable_separate | false | NOTICE | [https://github.com/Azure/tflint-ruleset-avm/blob/main/doc...](https://github.com/Azure/tflint-ruleset-avm/blob/main/docs/basic/terraform_variable_separate.md) |
 | terraform_versions_file | false | NOTICE | - |
 | tfnfr26 | false | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/terr...](https://azure.github.io/Azure-Verified-Modules/specs/terraform/#id-tfnfr26---category-code-style---providers-must-be-declared-in-the-required_providers-block-in-terraformtf-and-must-have-a-constraint-on-minimum-and-maximum-major-version) |
+| timeouts | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/spec/TFFR7/](https://azure.github.io/Azure-Verified-Modules/spec/TFFR7/) |

--- a/integration/azapi-required-interfaces-child/.tflint.hcl
+++ b/integration/azapi-required-interfaces-child/.tflint.hcl
@@ -1,0 +1,11 @@
+plugin "terraform" {
+  enabled = false
+}
+
+plugin "avm" {
+  enabled = true
+}
+
+rule "required_module_source_tffr1" {
+  enabled = false
+}

--- a/integration/azapi-required-interfaces-child/child/.tflint.hcl
+++ b/integration/azapi-required-interfaces-child/child/.tflint.hcl
@@ -1,0 +1,7 @@
+plugin "terraform" {
+  enabled = false
+}
+
+plugin "avm" {
+  enabled = true
+}

--- a/integration/azapi-required-interfaces-child/child/main.tf
+++ b/integration/azapi-required-interfaces-child/child/main.tf
@@ -1,0 +1,46 @@
+resource "azapi_resource" "example" {
+  type                   = var.resource_types.widget
+  name                   = "example"
+  parent_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example"
+  response_export_values = []
+  replace_triggers_refs  = []
+}
+
+variable "resource_types" {
+  type = object({
+    widget = optional(string, "Microsoft.Example/widgets@2024-01-01")
+  })
+  default  = {}
+  nullable = false
+}
+
+variable "retry" {
+  type = object({
+    error_message_regex  = optional(list(string))
+    interval_seconds     = optional(number)
+    max_interval_seconds = optional(number)
+  })
+  default = null
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    read   = optional(string)
+    update = optional(string)
+    delete = optional(string)
+  })
+  default = null
+}
+
+variable "ignore_body_changes" {
+  type = object({
+    widget = optional(list(string), [])
+  })
+  default  = {}
+  nullable = false
+}
+
+output "resource_id" {
+  value = azapi_resource.example.id
+}

--- a/integration/azapi-required-interfaces-child/child/terraform.tf
+++ b/integration/azapi-required-interfaces-child/child/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.12"
+    }
+    modtm = {
+      source  = "Azure/modtm"
+      version = "~> 0.3"
+    }
+  }
+}

--- a/integration/azapi-required-interfaces-child/main.tf
+++ b/integration/azapi-required-interfaces-child/main.tf
@@ -1,0 +1,7 @@
+module "child" {
+  source = "./child"
+}
+
+output "resource_id" {
+  value = module.child.resource_id
+}

--- a/integration/azapi-required-interfaces-child/terraform.tf
+++ b/integration/azapi-required-interfaces-child/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    modtm = {
+      source  = "Azure/modtm"
+      version = "~> 0.3"
+    }
+  }
+}

--- a/integration/azapi-required-interfaces-incorrect/.tflint.hcl
+++ b/integration/azapi-required-interfaces-incorrect/.tflint.hcl
@@ -1,0 +1,7 @@
+plugin "terraform" {
+  enabled = false
+}
+
+plugin "avm" {
+  enabled = true
+}

--- a/integration/azapi-required-interfaces-incorrect/main.tf
+++ b/integration/azapi-required-interfaces-incorrect/main.tf
@@ -1,0 +1,11 @@
+resource "azapi_resource" "example" {
+  type                   = "Microsoft.Example/widgets@2024-01-01"
+  name                   = "example"
+  parent_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example"
+  response_export_values = []
+  replace_triggers_refs  = []
+}
+
+output "resource_id" {
+  value = azapi_resource.example.id
+}

--- a/integration/azapi-required-interfaces-incorrect/terraform.tf
+++ b/integration/azapi-required-interfaces-incorrect/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.12"
+    }
+    modtm = {
+      source  = "Azure/modtm"
+      version = "~> 0.3"
+    }
+  }
+}

--- a/integration/azapi-required-interfaces/.tflint.hcl
+++ b/integration/azapi-required-interfaces/.tflint.hcl
@@ -1,0 +1,7 @@
+plugin "terraform" {
+  enabled = false
+}
+
+plugin "avm" {
+  enabled = true
+}

--- a/integration/azapi-required-interfaces/main.tf
+++ b/integration/azapi-required-interfaces/main.tf
@@ -1,0 +1,48 @@
+resource "azapi_resource" "example" {
+  type                   = var.resource_types.widget
+  name                   = "example"
+  parent_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example"
+  response_export_values = []
+  replace_triggers_refs  = []
+}
+
+variable "resource_types" {
+  type = object({
+    widget = optional(string, "Microsoft.Example/widgets@2024-01-01")
+  })
+  default  = {}
+  nullable = false
+}
+
+variable "retry" {
+  type = object({
+    error_message_regex  = optional(list(string))
+    interval_seconds     = optional(number)
+    max_interval_seconds = optional(number)
+  })
+  default = {}
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    read   = optional(string)
+    update = optional(string)
+    delete = optional(string)
+  })
+  default = {
+    delete = "30m"
+  }
+}
+
+variable "ignore_body_changes" {
+  type = object({
+    widget = optional(list(string), [])
+  })
+  default  = {}
+  nullable = false
+}
+
+output "resource_id" {
+  value = azapi_resource.example.id
+}

--- a/integration/azapi-required-interfaces/terraform.tf
+++ b/integration/azapi-required-interfaces/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.12"
+    }
+    modtm = {
+      source  = "Azure/modtm"
+      version = "~> 0.3"
+    }
+  }
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -72,6 +72,29 @@ func TestIntegration(t *testing.T) {
 				{Name: "azurerm_arg_order", Severity: "info"},
 			},
 		},
+		{
+			Name: "azapi-required-interfaces",
+			Dir:  "azapi-required-interfaces",
+		},
+		{
+			Name: "azapi-required-interfaces-incorrect",
+			Dir:  "azapi-required-interfaces-incorrect",
+			ExpectedIssues: []expectedIssue{
+				{Name: "ignore_body_changes", Severity: "error"},
+				{Name: "resource_types", Severity: "error"},
+				{Name: "retry", Severity: "error"},
+				{Name: "timeouts", Severity: "error"},
+			},
+			ExpectFailure: true,
+		},
+		{
+			Name: "azapi-required-interfaces-child-parent",
+			Dir:  "azapi-required-interfaces-child",
+		},
+		{
+			Name: "azapi-required-interfaces-child-module",
+			Dir:  filepath.Join("azapi-required-interfaces-child", "child"),
+		},
 	}
 
 	dir, _ := os.Getwd()

--- a/integration/interface-private-endpoint-deprecated/template.tf
+++ b/integration/interface-private-endpoint-deprecated/template.tf
@@ -34,6 +34,12 @@ variable "private_endpoints" {
   nullable = false
 }
 
+variable "private_endpoints_manage_dns_zone_group" {
+  type     = bool
+  default  = true
+  nullable = false
+}
+
 output "resource_id" {
   value = ""
 }

--- a/integration/interface-private-endpoint-incorrect/template.tf
+++ b/integration/interface-private-endpoint-incorrect/template.tf
@@ -11,6 +11,12 @@ variable "private_endpoints" {
   DESCRIPTION
 }
 
+variable "private_endpoints_manage_dns_zone_group" {
+  type     = bool
+  default  = true
+  nullable = false
+}
+
 output "resource_id" {
   # Just make var.private_endpoints an used variable, not mean to be valid.
   value = var.private_endpoints["default"].name

--- a/integration/interface-private-endpoint/template.tf
+++ b/integration/interface-private-endpoint/template.tf
@@ -37,6 +37,12 @@ variable "private_endpoints" {
   nullable    = false
 }
 
+variable "private_endpoints_manage_dns_zone_group" {
+  type     = bool
+  default  = true
+  nullable = false
+}
+
 output "resource_id" {
   value = ""
 }

--- a/interfaces/azapi_required_interfaces.go
+++ b/interfaces/azapi_required_interfaces.go
@@ -1,0 +1,281 @@
+package interfaces
+
+import (
+	"github.com/hashicorp/hcl/v2/ext/typeexpr"
+	"github.com/matt-FFFFFF/tfvarcheck/varcheck"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+)
+
+const (
+	resourceTypesRuleLink      = "https://azure.github.io/Azure-Verified-Modules/spec/TFFR6/"
+	retryTimeoutsRuleLink      = "https://azure.github.io/Azure-Verified-Modules/spec/TFFR7/"
+	ignoreBodyChangesRuleLink  = "https://azure.github.io/Azure-Verified-Modules/spec/TFFR8/"
+	privateEndpointsSchemaLink = "https://azure.github.io/Azure-Verified-Modules/includes/interfaces/tf/int.pe.schema.tf"
+)
+
+const retryTypeString = `object({
+  error_message_regex  = optional(list(string))
+  interval_seconds     = optional(number)
+  max_interval_seconds = optional(number)
+})`
+
+const timeoutsTypeString = `object({
+  create = optional(string)
+  read   = optional(string)
+  update = optional(string)
+  delete = optional(string)
+})`
+
+var requiredInterfaceRules = []tflint.Rule{
+	newRequiredVariableRule(
+		"resource_types",
+		resourceTypesRuleLink,
+		"when the module directly declares an AzAPI resource",
+		appliesToDirectAzapiResource,
+		validateVariableShape(variableShape{
+			typeDescription:     "must recursively contain optional string resource leaves and optional object submodule slots with canonical defaults",
+			defaultDescription:  "must be `{}`",
+			nullableDescription: "must be `false`",
+			validateType:        validateResourceTypesType,
+			validateDefault:     emptyObjectDefault,
+			nullable:            nullableMustBeFalse,
+		}),
+	),
+	newRequiredVariableRule(
+		"retry",
+		retryTimeoutsRuleLink,
+		"when the module directly declares an AzAPI resource",
+		appliesToDirectAzapiResource,
+		validateVariableShape(variableShape{
+			typeDescription:     "must use the TFFR7 retry object shape with optional fields",
+			defaultDescription:  "must be `null`, `{}`, or an object containing legal retry field defaults",
+			nullableDescription: "must permit `null`",
+			validateType: func(got varcheck.TypeConstraintWithDefaults) bool {
+				return validateFlatOptionalObject(got, map[string]cty.Type{
+					"error_message_regex":  cty.List(cty.String),
+					"interval_seconds":     cty.Number,
+					"max_interval_seconds": cty.Number,
+				})
+			},
+			validateDefault: nullableObjectDefault,
+			nullable:        nullableMayBeTrue,
+		}),
+	),
+	newRequiredVariableRule(
+		"timeouts",
+		retryTimeoutsRuleLink,
+		"when the module directly declares an AzAPI resource",
+		appliesToDirectAzapiResource,
+		validateVariableShape(variableShape{
+			typeDescription:     "must use the TFFR7 timeouts object shape with optional fields",
+			defaultDescription:  "must be `null`, `{}`, or an object containing legal timeout field defaults",
+			nullableDescription: "must permit `null`",
+			validateType: func(got varcheck.TypeConstraintWithDefaults) bool {
+				return validateFlatOptionalObject(got, map[string]cty.Type{
+					"create": cty.String,
+					"read":   cty.String,
+					"update": cty.String,
+					"delete": cty.String,
+				})
+			},
+			validateDefault: nullableObjectDefault,
+			nullable:        nullableMayBeTrue,
+		}),
+	),
+	newRequiredVariableRule(
+		"ignore_body_changes",
+		ignoreBodyChangesRuleLink,
+		"when the module directly declares an AzAPI resource",
+		appliesToDirectAzapiResource,
+		validateVariableShape(variableShape{
+			typeDescription:     "must recursively contain optional list(string) resource leaves with valid defaults and optional object submodule slots defaulting to `{}`",
+			defaultDescription:  "must be `{}`",
+			nullableDescription: "must be `false`",
+			validateType:        validateIgnoreBodyChangesType,
+			validateDefault:     emptyObjectDefault,
+			nullable:            nullableMustBeFalse,
+		}),
+	),
+	newRequiredVariableRule(
+		"private_endpoints_manage_dns_zone_group",
+		privateEndpointsSchemaLink,
+		"when variable `private_endpoints` is declared",
+		appliesWhenVariableDeclared("private_endpoints"),
+		validateVariableShape(variableShape{
+			typeDescription:     "must be `bool`",
+			defaultDescription:  "must be `true`",
+			nullableDescription: "must be `false`",
+			validateType: func(got varcheck.TypeConstraintWithDefaults) bool {
+				return got.Type.Equals(cty.Bool) && got.Default == nil
+			},
+			validateDefault: func(got cty.Value, _ varcheck.TypeConstraintWithDefaults) bool {
+				return got.Type().Equals(cty.Bool) && !got.IsNull() && got.True()
+			},
+			nullable: nullableMustBeFalse,
+		}),
+	),
+}
+
+func validateResourceTypesType(got varcheck.TypeConstraintWithDefaults) bool {
+	if !got.Type.IsObjectType() {
+		return false
+	}
+
+	directLeaves, ok := validateRecursiveObject(got.Type, got.Default, 0, resourceTypeLeaf)
+	return ok && directLeaves > 0
+}
+
+func validateIgnoreBodyChangesType(got varcheck.TypeConstraintWithDefaults) bool {
+	if !got.Type.IsObjectType() {
+		return false
+	}
+
+	directLeaves, ok := validateRecursiveObject(got.Type, got.Default, 0, ignoreBodyChangesLeaf)
+	return ok && directLeaves > 0
+}
+
+type recursiveLeafValidator func(cty.Type, *typeexpr.Defaults, string, int) bool
+
+func validateRecursiveObject(
+	objectType cty.Type,
+	defaults *typeexpr.Defaults,
+	depth int,
+	validateLeaf recursiveLeafValidator,
+) (int, bool) {
+	if !objectType.IsObjectType() {
+		return 0, false
+	}
+
+	directLeaves := 0
+	for name, attributeType := range objectType.AttributeTypes() {
+		if !objectType.AttributeOptional(name) {
+			return 0, false
+		}
+
+		if attributeType.IsObjectType() {
+			if !hasSemanticEmptyObjectDefault(defaults, name, attributeType) {
+				return 0, false
+			}
+
+			childDefaults := defaultsChild(defaults, name)
+			if _, ok := validateRecursiveObject(attributeType, childDefaults, depth+1, validateLeaf); !ok {
+				return 0, false
+			}
+			continue
+		}
+
+		if !validateLeaf(attributeType, defaults, name, depth) {
+			return 0, false
+		}
+		if depth == 0 {
+			directLeaves++
+		}
+	}
+
+	return directLeaves, true
+}
+
+func resourceTypeLeaf(attributeType cty.Type, defaults *typeexpr.Defaults, name string, depth int) bool {
+	if !attributeType.Equals(cty.String) {
+		return false
+	}
+
+	defaultValue, hasDefault := defaultsValue(defaults, name)
+	if depth > 0 {
+		return !hasDefault
+	}
+	if !hasDefault || !defaultValue.IsKnown() || defaultValue.IsNull() || !defaultValue.Type().Equals(cty.String) {
+		return false
+	}
+	return defaultValue.AsString() != ""
+}
+
+func ignoreBodyChangesLeaf(attributeType cty.Type, defaults *typeexpr.Defaults, name string, _ int) bool {
+	if !attributeType.Equals(cty.List(cty.String)) {
+		return false
+	}
+
+	defaultValue, hasDefault := defaultsValue(defaults, name)
+	if !hasDefault || !defaultValue.IsKnown() || defaultValue.IsNull() || !defaultValue.Type().Equals(cty.List(cty.String)) {
+		return false
+	}
+
+	for iterator := defaultValue.ElementIterator(); iterator.Next(); {
+		_, element := iterator.Element()
+		if !element.IsKnown() || element.IsNull() || element.AsString() == "" {
+			return false
+		}
+	}
+
+	return true
+}
+
+func validateFlatOptionalObject(got varcheck.TypeConstraintWithDefaults, expected map[string]cty.Type) bool {
+	if !got.Type.IsObjectType() || len(got.Type.AttributeTypes()) != len(expected) {
+		return false
+	}
+
+	for name, expectedType := range expected {
+		if !got.Type.HasAttribute(name) || !got.Type.AttributeOptional(name) {
+			return false
+		}
+		if !got.Type.AttributeType(name).Equals(expectedType) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func emptyObjectDefault(got cty.Value, _ varcheck.TypeConstraintWithDefaults) bool {
+	return got.RawEquals(cty.EmptyObjectVal)
+}
+
+func nullableObjectDefault(got cty.Value, typeConstraint varcheck.TypeConstraintWithDefaults) bool {
+	if got.IsNull() {
+		return true
+	}
+	if !got.Type().IsObjectType() {
+		return false
+	}
+
+	for name, value := range got.AsValueMap() {
+		if !typeConstraint.Type.HasAttribute(name) {
+			return false
+		}
+		if value.IsNull() {
+			continue
+		}
+		if _, err := convert.Convert(value, typeConstraint.Type.AttributeType(name)); err != nil {
+			return false
+		}
+	}
+
+	return true
+}
+
+func hasSemanticEmptyObjectDefault(defaults *typeexpr.Defaults, name string, objectType cty.Type) bool {
+	actual, ok := defaultsValue(defaults, name)
+	if !ok {
+		return false
+	}
+	expected, err := convert.Convert(cty.EmptyObjectVal, objectType)
+	return err == nil && actual.RawEquals(expected)
+}
+
+func defaultsValue(defaults *typeexpr.Defaults, name string) (cty.Value, bool) {
+	if defaults == nil {
+		return cty.NilVal, false
+	}
+	value, ok := defaults.DefaultValues[name]
+	return value, ok
+}
+
+func defaultsChild(defaults *typeexpr.Defaults, name string) *typeexpr.Defaults {
+	if defaults == nil {
+		return nil
+	}
+	return defaults.Children[name]
+}

--- a/interfaces/ignore_body_changes_test.go
+++ b/interfaces/ignore_body_changes_test.go
@@ -1,0 +1,179 @@
+package interfaces_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+// Canonical TFFR8 snapshot:
+// https://github.com/Azure/Azure-Verified-Modules/blob/005b4f94e9197d1e23ea4213c92b4263bf636a2e/docs/content/specs-defs/includes/terraform/shared/functional/TFFR8.md
+const validIgnoreBodyChanges = `resource "azapi_resource" "example" {
+  type = "Microsoft.Example/widgets@2024-01-01"
+}
+
+variable "ignore_body_changes" {
+  type = object({
+    widget = optional(list(string), [])
+    child = optional(object({
+      child_widget = optional(list(string), [])
+      grandchild = optional(object({
+        grandchild_widget = optional(list(string), [])
+      }), {})
+    }), {})
+  })
+  default  = {}
+  nullable = false
+}`
+
+func TestIgnoreBodyChangesValidRecursiveShape(t *testing.T) {
+	rule := requiredInterfaceRule(t, "ignore_body_changes")
+	cases := map[string]string{
+		"empty resource leaf defaults": validIgnoreBodyChanges,
+		"nonempty resource leaf default": strings.Replace(
+			validIgnoreBodyChanges,
+			"widget = optional(list(string), [])",
+			`widget = optional(list(string), ["properties.status"])`,
+			1,
+		),
+	}
+
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"main.tf": content})
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			helper.AssertIssues(t, helper.Issues{}, runner.Issues)
+		})
+	}
+}
+
+func TestIgnoreBodyChangesRejectMalformedRecursiveShapes(t *testing.T) {
+	rule := requiredInterfaceRule(t, "ignore_body_changes")
+	expectation := "must recursively contain optional list(string) resource leaves with valid defaults and optional object submodule slots defaulting to `{}`"
+	cases := map[string]string{
+		"top level map": `resource "azapi_resource" "example" {}
+
+variable "ignore_body_changes" {
+  type     = map(list(string))
+  default  = {}
+  nullable = false
+}`,
+		"required resource leaf": strings.Replace(
+			validIgnoreBodyChanges,
+			"widget = optional(list(string), [])",
+			"widget = list(string)",
+			1,
+		),
+		"resource leaf without empty default": strings.Replace(
+			validIgnoreBodyChanges,
+			"widget = optional(list(string), [])",
+			"widget = optional(list(string))",
+			1,
+		),
+		"resource leaf with empty string default": strings.Replace(
+			validIgnoreBodyChanges,
+			"widget = optional(list(string), [])",
+			`widget = optional(list(string), [""])`,
+			1,
+		),
+		"resource leaf with wrong element type": strings.Replace(
+			validIgnoreBodyChanges,
+			"child_widget = optional(list(string), [])",
+			"child_widget = optional(list(number), [])",
+			1,
+		),
+		"required child object": strings.NewReplacer(
+			"grandchild = optional(object({",
+			"grandchild = object({",
+			"      }), {})",
+			"      })",
+		).Replace(validIgnoreBodyChanges),
+		"child object without empty default": strings.Replace(
+			validIgnoreBodyChanges,
+			"}), {})",
+			"}))",
+			1,
+		),
+		"child object with null default": strings.Replace(
+			validIgnoreBodyChanges,
+			"}), {})",
+			"}), null)",
+			1,
+		),
+		"no direct resource leaf": strings.Replace(
+			validIgnoreBodyChanges,
+			"    widget = optional(list(string), [])\n",
+			"",
+			1,
+		),
+	}
+
+	for name, content := range cases {
+		content := content
+		t.Run(name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"main.tf": content})
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			helper.AssertIssuesWithoutRange(
+				t,
+				expectedVariableAttributeIssue(rule, "type", expectation, hcl.Range{}),
+				runner.Issues,
+			)
+		})
+	}
+}
+
+func TestIgnoreBodyChangesRejectDefaultAndNullability(t *testing.T) {
+	rule := requiredInterfaceRule(t, "ignore_body_changes")
+	cases := []struct {
+		name        string
+		content     string
+		attribute   string
+		expectation string
+	}{
+		{
+			name:        "missing default",
+			content:     strings.Replace(validIgnoreBodyChanges, "  default  = {}\n", "", 1),
+			attribute:   "default",
+			expectation: "must be `{}`",
+		},
+		{
+			name:        "nonempty default",
+			content:     strings.Replace(validIgnoreBodyChanges, "default  = {}", "default  = { widget = [\"properties.status\"] }", 1),
+			attribute:   "default",
+			expectation: "must be `{}`",
+		},
+		{
+			name:        "missing nullable",
+			content:     strings.Replace(validIgnoreBodyChanges, "  nullable = false\n", "", 1),
+			attribute:   "nullable",
+			expectation: "must be `false`",
+		},
+		{
+			name:        "nullable true",
+			content:     strings.Replace(validIgnoreBodyChanges, "nullable = false", "nullable = true", 1),
+			attribute:   "nullable",
+			expectation: "must be `false`",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"main.tf": tc.content})
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			helper.AssertIssuesWithoutRange(
+				t,
+				expectedVariableAttributeIssue(rule, tc.attribute, tc.expectation, hcl.Range{}),
+				runner.Issues,
+			)
+		})
+	}
+}

--- a/interfaces/interfaces.go
+++ b/interfaces/interfaces.go
@@ -36,7 +36,7 @@ var interfaceRuleRegistrations = []interfaceRuleRegistration{
 }
 
 var Rules = func() []tflint.Rule {
-	rules := make([]tflint.Rule, 0, len(interfaceRuleRegistrations)+3)
+	rules := make([]tflint.Rule, 0, len(interfaceRuleRegistrations)+3+len(requiredInterfaceRules))
 	for _, registration := range interfaceRuleRegistrations {
 		if len(registration.variants) == 1 {
 			rules = append(rules, NewVarCheckRuleFromAvmInterface(registration.variants[0]))
@@ -45,7 +45,7 @@ var Rules = func() []tflint.Rule {
 		rules = append(rules, newEitherInterfaceRule(registration.name, registration.variants...))
 	}
 
-	return append(rules,
+	rules = append(rules,
 		newDeprecatedInterfaceVariantRule(
 			"deprecated_lock_interface",
 			"lock",
@@ -68,4 +68,5 @@ var Rules = func() []tflint.Rule {
 			privateEndpointVariants[1:]...,
 		),
 	)
+	return append(rules, requiredInterfaceRules...)
 }()

--- a/interfaces/private_endpoints_manage_dns_zone_group_test.go
+++ b/interfaces/private_endpoints_manage_dns_zone_group_test.go
@@ -1,0 +1,147 @@
+package interfaces_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+// Canonical private endpoint schema snapshot:
+// https://github.com/Azure/Azure-Verified-Modules/blob/005b4f94e9197d1e23ea4213c92b4263bf636a2e/docs/static/includes/interfaces/tf/int.pe.schema.tf
+const validPrivateEndpointsManageDNSZoneGroup = `variable "private_endpoints" {
+  type    = map(any)
+  default = {}
+}
+
+variable "private_endpoints_manage_dns_zone_group" {
+  type     = bool
+  default  = true
+  nullable = false
+}`
+
+func TestPrivateEndpointsManageDNSZoneGroupValid(t *testing.T) {
+	rule := requiredInterfaceRule(t, "private_endpoints_manage_dns_zone_group")
+	runner := helper.TestRunner(t, map[string]string{"variables.tf": validPrivateEndpointsManageDNSZoneGroup})
+
+	if err := rule.Check(runner); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	helper.AssertIssues(t, helper.Issues{}, runner.Issues)
+}
+
+func TestPrivateEndpointsManageDNSZoneGroupRequiredConditionally(t *testing.T) {
+	rule := requiredInterfaceRule(t, "private_endpoints_manage_dns_zone_group")
+	content := `variable "private_endpoints" {
+  type    = map(any)
+  default = {}
+}`
+	runner := helper.TestRunner(t, map[string]string{"variables.tf": content})
+
+	if err := rule.Check(runner); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	helper.AssertIssues(t, helper.Issues{
+		{
+			Rule:    rule,
+			Message: "variable `private_endpoints_manage_dns_zone_group` must be declared when variable `private_endpoints` is declared; see: " + rule.Link(),
+			Range: hcl.Range{
+				Filename: "variables.tf",
+				Start:    hcl.Pos{Line: 1, Column: 1},
+				End:      hcl.Pos{Line: 1, Column: 29},
+			},
+		},
+	}, runner.Issues)
+}
+
+func TestPrivateEndpointsManageDNSZoneGroupSkipsWhenPrivateEndpointsAbsent(t *testing.T) {
+	rule := requiredInterfaceRule(t, "private_endpoints_manage_dns_zone_group")
+	content := `variable "private_endpoints_manage_dns_zone_group" {
+  type     = string
+  default  = false
+  nullable = true
+}`
+	runner := helper.TestRunner(t, map[string]string{"variables.tf": content})
+
+	if err := rule.Check(runner); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	helper.AssertIssues(t, helper.Issues{}, runner.Issues)
+}
+
+func TestPrivateEndpointsManageDNSZoneGroupRejectsMalformedDeclaration(t *testing.T) {
+	rule := requiredInterfaceRule(t, "private_endpoints_manage_dns_zone_group")
+	cases := []struct {
+		name        string
+		content     string
+		attribute   string
+		expectation string
+	}{
+		{
+			name:        "wrong type",
+			content:     strings.Replace(validPrivateEndpointsManageDNSZoneGroup, "type     = bool", "type     = string", 1),
+			attribute:   "type",
+			expectation: "must be `bool`",
+		},
+		{
+			name:        "false default",
+			content:     strings.Replace(validPrivateEndpointsManageDNSZoneGroup, "default  = true", "default  = false", 1),
+			attribute:   "default",
+			expectation: "must be `true`",
+		},
+		{
+			name:        "missing default",
+			content:     strings.Replace(validPrivateEndpointsManageDNSZoneGroup, "  default  = true\n", "", 1),
+			attribute:   "default",
+			expectation: "must be `true`",
+		},
+		{
+			name:        "nullable true",
+			content:     strings.Replace(validPrivateEndpointsManageDNSZoneGroup, "nullable = false", "nullable = true", 1),
+			attribute:   "nullable",
+			expectation: "must be `false`",
+		},
+		{
+			name:        "missing nullable",
+			content:     strings.Replace(validPrivateEndpointsManageDNSZoneGroup, "  nullable = false\n", "", 1),
+			attribute:   "nullable",
+			expectation: "must be `false`",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"variables.tf": tc.content})
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			helper.AssertIssuesWithoutRange(
+				t,
+				expectedVariableAttributeIssue(rule, tc.attribute, tc.expectation, hcl.Range{}),
+				runner.Issues,
+			)
+		})
+	}
+}
+
+func TestPrivateEndpointsManageDNSZoneGroupMalformedSourceRange(t *testing.T) {
+	rule := requiredInterfaceRule(t, "private_endpoints_manage_dns_zone_group")
+	content := strings.Replace(validPrivateEndpointsManageDNSZoneGroup, "type     = bool", "type     = string", 1)
+	runner := helper.TestRunner(t, map[string]string{"variables.tf": content})
+
+	if err := rule.Check(runner); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	helper.AssertIssues(t, expectedVariableAttributeIssue(
+		rule,
+		"type",
+		"must be `bool`",
+		hcl.Range{
+			Filename: "variables.tf",
+			Start:    hcl.Pos{Line: 7, Column: 3},
+			End:      hcl.Pos{Line: 7, Column: 20},
+		},
+	), runner.Issues)
+}

--- a/interfaces/required_interface.go
+++ b/interfaces/required_interface.go
@@ -1,0 +1,219 @@
+package interfaces
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/matt-FFFFFF/tfvarcheck/varcheck"
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/zclconf/go-cty/cty"
+)
+
+var azapiResourceBodySchema = &hclext.BodySchema{
+	Blocks: []hclext.BlockSchema{
+		{
+			Type:       "resource",
+			LabelNames: []string{"type", "name"},
+			Body:       &hclext.BodySchema{},
+		},
+	},
+}
+
+var mandatoryInterfaceAzapiResourceTypes = map[string]struct{}{
+	"azapi_data_plane_resource": {},
+	"azapi_resource":            {},
+	"azapi_resource_action":     {},
+	"azapi_update_resource":     {},
+}
+
+type requiredVariableApplicability func(tflint.Runner) (bool, hcl.Range, error)
+
+type requiredVariableValidator func(*requiredVariableRule, tflint.Runner, *hclext.Block) error
+
+type requiredVariableRule struct {
+	tflint.DefaultRule
+
+	name          string
+	link          string
+	requirement   string
+	applicability requiredVariableApplicability
+	validator     requiredVariableValidator
+}
+
+func newRequiredVariableRule(
+	name string,
+	link string,
+	requirement string,
+	applicability requiredVariableApplicability,
+	validator requiredVariableValidator,
+) *requiredVariableRule {
+	return &requiredVariableRule{
+		name:          name,
+		link:          link,
+		requirement:   requirement,
+		applicability: applicability,
+		validator:     validator,
+	}
+}
+
+func (r *requiredVariableRule) Name() string {
+	return r.name
+}
+
+func (r *requiredVariableRule) Link() string {
+	return r.link
+}
+
+func (r *requiredVariableRule) Enabled() bool {
+	return true
+}
+
+func (r *requiredVariableRule) Severity() tflint.Severity {
+	return tflint.ERROR
+}
+
+func (r *requiredVariableRule) Check(runner tflint.Runner) error {
+	applicable, sourceRange, err := r.applicability(runner)
+	if err != nil || !applicable {
+		return err
+	}
+
+	variable, err := findVariableDeclaration(runner, r.name)
+	if err != nil {
+		return err
+	}
+	if variable == nil {
+		return runner.EmitIssue(
+			r,
+			fmt.Sprintf("variable `%s` must be declared %s; see: %s", r.name, r.requirement, r.link),
+			sourceRange,
+		)
+	}
+
+	return r.validator(r, runner, variable)
+}
+
+func appliesToDirectAzapiResource(runner tflint.Runner) (bool, hcl.Range, error) {
+	content, err := runner.GetModuleContent(
+		azapiResourceBodySchema,
+		&tflint.GetModuleContentOption{ExpandMode: tflint.ExpandModeNone},
+	)
+	if err != nil {
+		return false, hcl.Range{}, err
+	}
+
+	for _, block := range content.Blocks {
+		if len(block.Labels) != 2 {
+			continue
+		}
+		if _, ok := mandatoryInterfaceAzapiResourceTypes[block.Labels[0]]; ok {
+			return true, block.DefRange, nil
+		}
+	}
+
+	return false, hcl.Range{}, nil
+}
+
+func appliesWhenVariableDeclared(name string) requiredVariableApplicability {
+	return func(runner tflint.Runner) (bool, hcl.Range, error) {
+		variable, err := findVariableDeclaration(runner, name)
+		if err != nil || variable == nil {
+			return false, hcl.Range{}, err
+		}
+		return true, variable.DefRange, nil
+	}
+}
+
+func findVariableDeclaration(runner tflint.Runner, name string) (*hclext.Block, error) {
+	content, err := runner.GetModuleContent(
+		variableBodySchema,
+		&tflint.GetModuleContentOption{ExpandMode: tflint.ExpandModeNone},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, block := range content.Blocks {
+		if len(block.Labels) == 1 && block.Labels[0] == name {
+			return block, nil
+		}
+	}
+
+	return nil, nil
+}
+
+type nullableRequirement int
+
+const (
+	nullableMustBeFalse nullableRequirement = iota
+	nullableMayBeTrue
+)
+
+type variableShape struct {
+	typeDescription     string
+	defaultDescription  string
+	nullableDescription string
+	validateType        func(varcheck.TypeConstraintWithDefaults) bool
+	validateDefault     func(cty.Value, varcheck.TypeConstraintWithDefaults) bool
+	nullable            nullableRequirement
+}
+
+func validateVariableShape(shape variableShape) requiredVariableValidator {
+	return func(rule *requiredVariableRule, runner tflint.Runner, block *hclext.Block) error {
+		typeAttr, ok := block.Body.Attributes["type"]
+		if !ok {
+			return emitVariableAttributeIssue(rule, runner, block.DefRange, "type", shape.typeDescription)
+		}
+
+		typeConstraint, diags := varcheck.NewTypeConstraintWithDefaultsFromExp(typeAttr.Expr)
+		if diags.HasErrors() || !shape.validateType(typeConstraint) {
+			return emitVariableAttributeIssue(rule, runner, typeAttr.Range, "type", shape.typeDescription)
+		}
+
+		defaultAttr, ok := block.Body.Attributes["default"]
+		if !ok {
+			return emitVariableAttributeIssue(rule, runner, block.DefRange, "default", shape.defaultDescription)
+		}
+		defaultValue, diags := defaultAttr.Expr.Value(nil)
+		if diags.HasErrors() || !defaultValue.IsKnown() || !shape.validateDefault(defaultValue, typeConstraint) {
+			return emitVariableAttributeIssue(rule, runner, defaultAttr.Range, "default", shape.defaultDescription)
+		}
+
+		nullableAttr, ok := block.Body.Attributes["nullable"]
+		if !ok {
+			if shape.nullable == nullableMayBeTrue {
+				return nil
+			}
+			return emitVariableAttributeIssue(rule, runner, block.DefRange, "nullable", shape.nullableDescription)
+		}
+
+		nullableValue, diags := nullableAttr.Expr.Value(nil)
+		if diags.HasErrors() || !nullableValue.IsKnown() || nullableValue.IsNull() || !nullableValue.Type().Equals(cty.Bool) {
+			return emitVariableAttributeIssue(rule, runner, nullableAttr.Range, "nullable", shape.nullableDescription)
+		}
+
+		if shape.nullable == nullableMustBeFalse && nullableValue.True() {
+			return emitVariableAttributeIssue(rule, runner, nullableAttr.Range, "nullable", shape.nullableDescription)
+		}
+		if shape.nullable == nullableMayBeTrue && !nullableValue.True() {
+			return emitVariableAttributeIssue(rule, runner, nullableAttr.Range, "nullable", shape.nullableDescription)
+		}
+
+		return nil
+	}
+}
+
+func emitVariableAttributeIssue(
+	rule *requiredVariableRule,
+	runner tflint.Runner,
+	sourceRange hcl.Range,
+	attribute string,
+	expectation string,
+) error {
+	return runner.EmitIssue(
+		rule,
+		fmt.Sprintf("variable `%s` %s %s; see: %s", rule.name, attribute, expectation, rule.link),
+		sourceRange,
+	)
+}

--- a/interfaces/required_interface_test.go
+++ b/interfaces/required_interface_test.go
@@ -1,0 +1,183 @@
+package interfaces_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/tflint-ruleset-avm/interfaces"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+var azapiRequiredVariableNames = []string{
+	"resource_types",
+	"retry",
+	"timeouts",
+	"ignore_body_changes",
+}
+
+func TestAzapiRequiredInterfacesTriggerOnEveryResourceType(t *testing.T) {
+	resourceTypes := []string{
+		"azapi_resource",
+		"azapi_data_plane_resource",
+		"azapi_resource_action",
+		"azapi_update_resource",
+	}
+
+	for _, resourceType := range resourceTypes {
+		resourceType := resourceType
+		t.Run(resourceType, func(t *testing.T) {
+			content := fmt.Sprintf(`resource %q "example" {
+  count    = 0
+  for_each = {}
+}`, resourceType)
+
+			for _, variableName := range azapiRequiredVariableNames {
+				rule := requiredInterfaceRule(t, variableName)
+				runner := helper.TestRunner(t, map[string]string{"main.tf": content})
+
+				if err := rule.Check(runner); err != nil {
+					t.Fatalf("%s: unexpected error: %s", variableName, err)
+				}
+				helper.AssertIssuesWithoutRange(t, helper.Issues{
+					{
+						Rule: rule,
+						Message: fmt.Sprintf(
+							"variable `%s` must be declared when the module directly declares an AzAPI resource; see: %s",
+							variableName,
+							rule.Link(),
+						),
+					},
+				}, runner.Issues)
+			}
+		})
+	}
+}
+
+func TestAzapiRequiredInterfacesIgnoreNonTriggers(t *testing.T) {
+	content := `provider "azapi" {}
+
+data "azapi_resource" "example" {
+  type      = "Microsoft.Example/widgets@2024-01-01"
+  parent_id = "example"
+  name      = "example"
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example"
+  location = "eastus"
+}
+
+module "child" {
+  source = "./child"
+}`
+
+	for _, variableName := range azapiRequiredVariableNames {
+		rule := requiredInterfaceRule(t, variableName)
+		runner := helper.TestRunner(t, map[string]string{"main.tf": content})
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("%s: unexpected error: %s", variableName, err)
+		}
+		helper.AssertIssues(t, helper.Issues{}, runner.Issues)
+	}
+}
+
+func TestAzapiRequiredInterfacesSkipValidationWhenNotApplicable(t *testing.T) {
+	for _, variableName := range azapiRequiredVariableNames {
+		variableName := variableName
+		t.Run(variableName, func(t *testing.T) {
+			content := fmt.Sprintf(`variable %q {
+  type     = string
+  default  = "invalid"
+  nullable = true
+}`, variableName)
+			rule := requiredInterfaceRule(t, variableName)
+			runner := helper.TestRunner(t, map[string]string{"variables.tf": content})
+
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			helper.AssertIssues(t, helper.Issues{}, runner.Issues)
+		})
+	}
+}
+
+func TestAzapiRequiredInterfacesEvaluateParentAndChildIndependently(t *testing.T) {
+	rule := requiredInterfaceRule(t, "resource_types")
+	parentRunner := helper.TestRunner(t, map[string]string{
+		"main.tf": `module "child" {
+  source = "./child"
+}`,
+	})
+	if err := rule.Check(parentRunner); err != nil {
+		t.Fatalf("parent: unexpected error: %s", err)
+	}
+	helper.AssertIssues(t, helper.Issues{}, parentRunner.Issues)
+
+	childRunner := helper.TestRunner(t, map[string]string{
+		"main.tf": `resource "azapi_resource" "child" {
+  type = "Microsoft.Example/children@2024-01-01"
+}`,
+	})
+	if err := rule.Check(childRunner); err != nil {
+		t.Fatalf("child: unexpected error: %s", err)
+	}
+	helper.AssertIssuesWithoutRange(t, helper.Issues{
+		{
+			Rule:    rule,
+			Message: "variable `resource_types` must be declared when the module directly declares an AzAPI resource; see: " + rule.Link(),
+		},
+	}, childRunner.Issues)
+}
+
+func TestAzapiRequiredInterfaceMissingVariableSourceRange(t *testing.T) {
+	rule := requiredInterfaceRule(t, "resource_types")
+	runner := helper.TestRunner(t, map[string]string{
+		"main.tf": `resource "azapi_resource" "example" {
+  type = "Microsoft.Example/widgets@2024-01-01"
+}`,
+	})
+
+	if err := rule.Check(runner); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	helper.AssertIssues(t, helper.Issues{
+		{
+			Rule:    rule,
+			Message: "variable `resource_types` must be declared when the module directly declares an AzAPI resource; see: " + rule.Link(),
+			Range: hcl.Range{
+				Filename: "main.tf",
+				Start:    hcl.Pos{Line: 1, Column: 1},
+				End:      hcl.Pos{Line: 1, Column: 36},
+			},
+		},
+	}, runner.Issues)
+}
+
+func requiredInterfaceRule(t *testing.T, name string) tflint.Rule {
+	t.Helper()
+	for _, rule := range interfaces.Rules {
+		if rule.Name() == name {
+			return rule
+		}
+	}
+	t.Fatalf("required interface rule %q is not registered", name)
+	return nil
+}
+
+func expectedVariableAttributeIssue(rule tflint.Rule, attribute, expectation string, sourceRange hcl.Range) helper.Issues {
+	return helper.Issues{
+		{
+			Rule: rule,
+			Message: fmt.Sprintf(
+				"variable `%s` %s %s; see: %s",
+				rule.Name(),
+				attribute,
+				expectation,
+				rule.Link(),
+			),
+			Range: sourceRange,
+		},
+	}
+}

--- a/interfaces/resource_types_test.go
+++ b/interfaces/resource_types_test.go
@@ -1,0 +1,188 @@
+package interfaces_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+// Canonical TFFR6 snapshot:
+// https://github.com/Azure/Azure-Verified-Modules/blob/005b4f94e9197d1e23ea4213c92b4263bf636a2e/docs/content/specs-defs/includes/terraform/shared/functional/TFFR6.md
+const validResourceTypes = `resource "azapi_resource" "example" {
+  type = var.resource_types.widget
+}
+
+variable "resource_types" {
+  type = object({
+    widget = optional(string, "Microsoft.Example/widgets@2024-01-01")
+    child = optional(object({
+      child_widget = optional(string)
+      grandchild = optional(object({
+        grandchild_widget = optional(string)
+      }), {})
+    }), {})
+  })
+  default  = {}
+  nullable = false
+}`
+
+func TestResourceTypesValidRecursiveShapes(t *testing.T) {
+	rule := requiredInterfaceRule(t, "resource_types")
+	cases := map[string]string{
+		"recursive": validResourceTypes,
+		"multiple owned resources": strings.Replace(
+			validResourceTypes,
+			`    widget = optional(string, "Microsoft.Example/widgets@2024-01-01")`,
+			`    widget       = optional(string, "Microsoft.Example/widgets@2024-01-01")
+    widget_child = optional(string, "Microsoft.Example/widgets/children@2024-01-01")`,
+			1,
+		),
+	}
+
+	for name, content := range cases {
+		content := content
+		t.Run(name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"main.tf": content})
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			helper.AssertIssues(t, helper.Issues{}, runner.Issues)
+		})
+	}
+}
+
+func TestResourceTypesRejectMalformedRecursiveShapes(t *testing.T) {
+	rule := requiredInterfaceRule(t, "resource_types")
+	expectation := "must recursively contain optional string resource leaves and optional object submodule slots with canonical defaults"
+	cases := map[string]string{
+		"top level map": `resource "azapi_resource" "example" {}
+
+variable "resource_types" {
+  type     = map(string)
+  default  = {}
+  nullable = false
+}`,
+		"required owned resource leaf": strings.Replace(
+			validResourceTypes,
+			`widget = optional(string, "Microsoft.Example/widgets@2024-01-01")`,
+			`widget = string`,
+			1,
+		),
+		"owned resource leaf without API default": strings.Replace(
+			validResourceTypes,
+			`widget = optional(string, "Microsoft.Example/widgets@2024-01-01")`,
+			`widget = optional(string)`,
+			1,
+		),
+		"owned resource leaf with empty API default": strings.Replace(
+			validResourceTypes,
+			`widget = optional(string, "Microsoft.Example/widgets@2024-01-01")`,
+			`widget = optional(string, "")`,
+			1,
+		),
+		"inherited resource leaf with parent default": strings.Replace(
+			validResourceTypes,
+			`child_widget = optional(string)`,
+			`child_widget = optional(string, "Microsoft.Example/children@2024-01-01")`,
+			1,
+		),
+		"required child object": strings.NewReplacer(
+			"grandchild = optional(object({",
+			"grandchild = object({",
+			"      }), {})",
+			"      })",
+		).Replace(validResourceTypes),
+		"child object without empty default": strings.Replace(
+			validResourceTypes,
+			"}), {})",
+			"}))",
+			1,
+		),
+		"child object with null default": strings.Replace(
+			validResourceTypes,
+			"}), {})",
+			"}), null)",
+			1,
+		),
+		"non string leaf": strings.Replace(
+			validResourceTypes,
+			`child_widget = optional(string)`,
+			`child_widget = optional(number)`,
+			1,
+		),
+		"no direct owned resource leaf": strings.Replace(
+			validResourceTypes,
+			`    widget = optional(string, "Microsoft.Example/widgets@2024-01-01")
+`,
+			"",
+			1,
+		),
+	}
+
+	for name, content := range cases {
+		content := content
+		t.Run(name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"main.tf": content})
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			helper.AssertIssuesWithoutRange(
+				t,
+				expectedVariableAttributeIssue(rule, "type", expectation, hcl.Range{}),
+				runner.Issues,
+			)
+		})
+	}
+}
+
+func TestResourceTypesRejectDefaultAndNullability(t *testing.T) {
+	rule := requiredInterfaceRule(t, "resource_types")
+	cases := []struct {
+		name        string
+		content     string
+		attribute   string
+		expectation string
+	}{
+		{
+			name:        "missing default",
+			content:     strings.Replace(validResourceTypes, "  default  = {}\n", "", 1),
+			attribute:   "default",
+			expectation: "must be `{}`",
+		},
+		{
+			name:        "null default",
+			content:     strings.Replace(validResourceTypes, "default  = {}", "default  = null", 1),
+			attribute:   "default",
+			expectation: "must be `{}`",
+		},
+		{
+			name:        "missing nullable",
+			content:     strings.Replace(validResourceTypes, "  nullable = false\n", "", 1),
+			attribute:   "nullable",
+			expectation: "must be `false`",
+		},
+		{
+			name:        "nullable true",
+			content:     strings.Replace(validResourceTypes, "nullable = false", "nullable = true", 1),
+			attribute:   "nullable",
+			expectation: "must be `false`",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"main.tf": tc.content})
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			helper.AssertIssuesWithoutRange(
+				t,
+				expectedVariableAttributeIssue(rule, tc.attribute, tc.expectation, hcl.Range{}),
+				runner.Issues,
+			)
+		})
+	}
+}

--- a/interfaces/retry_timeouts_test.go
+++ b/interfaces/retry_timeouts_test.go
@@ -1,0 +1,276 @@
+package interfaces_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// Canonical TFFR7 snapshot:
+// https://github.com/Azure/Azure-Verified-Modules/blob/005b4f94e9197d1e23ea4213c92b4263bf636a2e/docs/content/specs-defs/includes/terraform/shared/functional/TFFR7.md
+const validRetry = `resource "azapi_resource" "example" {
+  type = "Microsoft.Example/widgets@2024-01-01"
+}
+
+variable "retry" {
+  type = object({
+    error_message_regex  = optional(list(string))
+    interval_seconds     = optional(number)
+    max_interval_seconds = optional(number)
+  })
+  default = null
+}`
+
+const validTimeouts = `resource "azapi_resource" "example" {
+  type = "Microsoft.Example/widgets@2024-01-01"
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    read   = optional(string)
+    update = optional(string)
+    delete = optional(string)
+  })
+  default = null
+}`
+
+func TestRetryAcceptsPermittedDefaults(t *testing.T) {
+	rule := requiredInterfaceRule(t, "retry")
+	cases := map[string]string{
+		"canonical null": validRetry,
+		"empty object":   strings.Replace(validRetry, "default = null", "default = {}", 1),
+		"module field defaults": strings.Replace(
+			validRetry,
+			"default = null",
+			`default = {
+    error_message_regex  = ["ScopeLocked"]
+    interval_seconds     = 10
+    max_interval_seconds = 60
+  }`,
+			1,
+		),
+		"optional field defaults": strings.NewReplacer(
+			"optional(list(string))", `optional(list(string), ["ScopeLocked"])`,
+			"optional(number)", "optional(number, 10)",
+		).Replace(validRetry),
+		"explicit nullable true": strings.Replace(
+			validRetry,
+			"  default = null\n",
+			"  default  = null\n  nullable = true\n",
+			1,
+		),
+	}
+
+	for name, content := range cases {
+		content := content
+		t.Run(name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"main.tf": content})
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			helper.AssertIssues(t, helper.Issues{}, runner.Issues)
+		})
+	}
+}
+
+func TestRetryRejectsMalformedTypeDefaultAndNullability(t *testing.T) {
+	rule := requiredInterfaceRule(t, "retry")
+	cases := []struct {
+		name        string
+		content     string
+		attribute   string
+		expectation string
+	}{
+		{
+			name:        "required field",
+			content:     strings.Replace(validRetry, "interval_seconds     = optional(number)", "interval_seconds     = number", 1),
+			attribute:   "type",
+			expectation: "must use the TFFR7 retry object shape with optional fields",
+		},
+		{
+			name:        "wrong field type",
+			content:     strings.Replace(validRetry, "max_interval_seconds = optional(number)", "max_interval_seconds = optional(string)", 1),
+			attribute:   "type",
+			expectation: "must use the TFFR7 retry object shape with optional fields",
+		},
+		{
+			name:        "missing field",
+			content:     strings.Replace(validRetry, "    max_interval_seconds = optional(number)\n", "", 1),
+			attribute:   "type",
+			expectation: "must use the TFFR7 retry object shape with optional fields",
+		},
+		{
+			name:        "extra field",
+			content:     strings.Replace(validRetry, "    max_interval_seconds = optional(number)\n", "    max_interval_seconds = optional(number)\n    unexpected           = optional(number)\n", 1),
+			attribute:   "type",
+			expectation: "must use the TFFR7 retry object shape with optional fields",
+		},
+		{
+			name:        "illegal optional field default",
+			content:     strings.Replace(validRetry, "optional(number)", `optional(number, ["invalid"])`, 1),
+			attribute:   "type",
+			expectation: "must use the TFFR7 retry object shape with optional fields",
+		},
+		{
+			name:        "missing module default",
+			content:     strings.Replace(validRetry, "  default = null\n", "", 1),
+			attribute:   "default",
+			expectation: "must be `null`, `{}`, or an object containing legal retry field defaults",
+		},
+		{
+			name:        "unknown module default field",
+			content:     strings.Replace(validRetry, "default = null", "default = { unexpected = true }", 1),
+			attribute:   "default",
+			expectation: "must be `null`, `{}`, or an object containing legal retry field defaults",
+		},
+		{
+			name:        "invalid module default field value",
+			content:     strings.Replace(validRetry, "default = null", "default = { interval_seconds = [10] }", 1),
+			attribute:   "default",
+			expectation: "must be `null`, `{}`, or an object containing legal retry field defaults",
+		},
+		{
+			name:        "nullable false",
+			content:     strings.Replace(validRetry, "  default = null\n", "  default  = null\n  nullable = false\n", 1),
+			attribute:   "nullable",
+			expectation: "must permit `null`",
+		},
+	}
+
+	runMalformedVariableCases(t, rule, cases)
+}
+
+func TestTimeoutsAcceptsPermittedDefaults(t *testing.T) {
+	rule := requiredInterfaceRule(t, "timeouts")
+	cases := map[string]string{
+		"canonical null": validTimeouts,
+		"empty object":   strings.Replace(validTimeouts, "default = null", "default = {}", 1),
+		"module field defaults": strings.Replace(
+			validTimeouts,
+			"default = null",
+			`default = {
+    create = "30m"
+    read   = "5m"
+    update = "30m"
+    delete = "30m"
+  }`,
+			1,
+		),
+		"optional field defaults": strings.ReplaceAll(validTimeouts, "optional(string)", `optional(string, "30m")`),
+		"explicit nullable true": strings.Replace(
+			validTimeouts,
+			"  default = null\n",
+			"  default  = null\n  nullable = true\n",
+			1,
+		),
+	}
+
+	for name, content := range cases {
+		content := content
+		t.Run(name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"main.tf": content})
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			helper.AssertIssues(t, helper.Issues{}, runner.Issues)
+		})
+	}
+}
+
+func TestTimeoutsRejectsMalformedTypeDefaultAndNullability(t *testing.T) {
+	rule := requiredInterfaceRule(t, "timeouts")
+	cases := []struct {
+		name        string
+		content     string
+		attribute   string
+		expectation string
+	}{
+		{
+			name:        "required field",
+			content:     strings.Replace(validTimeouts, "create = optional(string)", "create = string", 1),
+			attribute:   "type",
+			expectation: "must use the TFFR7 timeouts object shape with optional fields",
+		},
+		{
+			name:        "wrong field type",
+			content:     strings.Replace(validTimeouts, "delete = optional(string)", "delete = optional(number)", 1),
+			attribute:   "type",
+			expectation: "must use the TFFR7 timeouts object shape with optional fields",
+		},
+		{
+			name:        "missing field",
+			content:     strings.Replace(validTimeouts, "    delete = optional(string)\n", "", 1),
+			attribute:   "type",
+			expectation: "must use the TFFR7 timeouts object shape with optional fields",
+		},
+		{
+			name:        "extra field",
+			content:     strings.Replace(validTimeouts, "    delete = optional(string)\n", "    delete     = optional(string)\n    unexpected = optional(string)\n", 1),
+			attribute:   "type",
+			expectation: "must use the TFFR7 timeouts object shape with optional fields",
+		},
+		{
+			name:        "illegal optional field default",
+			content:     strings.Replace(validTimeouts, "optional(string)", `optional(string, ["30m"])`, 1),
+			attribute:   "type",
+			expectation: "must use the TFFR7 timeouts object shape with optional fields",
+		},
+		{
+			name:        "missing module default",
+			content:     strings.Replace(validTimeouts, "  default = null\n", "", 1),
+			attribute:   "default",
+			expectation: "must be `null`, `{}`, or an object containing legal timeout field defaults",
+		},
+		{
+			name:        "unknown module default field",
+			content:     strings.Replace(validTimeouts, "default = null", "default = { unexpected = \"5m\" }", 1),
+			attribute:   "default",
+			expectation: "must be `null`, `{}`, or an object containing legal timeout field defaults",
+		},
+		{
+			name:        "invalid module default field value",
+			content:     strings.Replace(validTimeouts, "default = null", "default = { create = [\"5m\"] }", 1),
+			attribute:   "default",
+			expectation: "must be `null`, `{}`, or an object containing legal timeout field defaults",
+		},
+		{
+			name:        "nullable false",
+			content:     strings.Replace(validTimeouts, "  default = null\n", "  default  = null\n  nullable = false\n", 1),
+			attribute:   "nullable",
+			expectation: "must permit `null`",
+		},
+	}
+
+	runMalformedVariableCases(t, rule, cases)
+}
+
+func runMalformedVariableCases(
+	t *testing.T,
+	rule tflint.Rule,
+	cases []struct {
+		name        string
+		content     string
+		attribute   string
+		expectation string
+	},
+) {
+	t.Helper()
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"main.tf": tc.content})
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			helper.AssertIssuesWithoutRange(
+				t,
+				expectedVariableAttributeIssue(rule, tc.attribute, tc.expectation, hcl.Range{}),
+				runner.Issues,
+			)
+		})
+	}
+}

--- a/interfaces/schema_format_test.go
+++ b/interfaces/schema_format_test.go
@@ -24,3 +24,22 @@ func TestRegisteredInterfaceSchemasAreCanonicalHCL(t *testing.T) {
 		}
 	}
 }
+
+func TestAzapiRequiredInterfaceSchemasAreCanonicalHCL(t *testing.T) {
+	for name, schema := range map[string]string{
+		"retry":    retryTypeString,
+		"timeouts": timeoutsTypeString,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if strings.ContainsRune(schema, '\t') {
+				t.Fatalf("schema contains a tab:\n%s", schema)
+			}
+
+			source := "schema = " + schema + "\n"
+			formatted := string(hclwrite.Format([]byte(source)))
+			if source != formatted {
+				t.Fatalf("schema is not canonical HCL formatting:\n%s\nformatted:\n%s", source, formatted)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- require `resource_types`, `retry`, `timeouts`, and `ignore_body_changes` only in module scopes that directly declare supported AzAPI resource blocks
- require `private_endpoints_manage_dns_zone_group` only when the canonical `private_endpoints` variable is declared
- validate canonical recursive types, semantic defaults, nullability, and source-precise diagnostics
- add unit and TFLint integration coverage for all trigger labels, non-triggers, conditional applicability, malformed declarations, and parent/child scope isolation
- regenerate `RULES.md` and the README rules table

The rule expectations are pinned in tests to Azure Verified Modules specification snapshot `005b4f94e9197d1e23ea4213c92b4263bf636a2e`.

## Validation

- `go test ./... -count=1`
- `golangci-lint run`
- `gosec ./...`
- TFLint integration suite with v0.64.0
- TFLint integration suite with minimum supported v0.62.0
- generated rules documentation equality check

## Release sequencing

This is a separate follow-up to [PR #147](https://github.com/Azure/tflint-ruleset-avm/pull/147), based on its merged commit. It must merge before cutting the single attested v0.19.0 release; it does not introduce a separate later release.