### PR TITLE
feat(rules): validate replacement trigger paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ plugin "avm" {
 | Name | Enabled | Severity | Link |
 | ---- | ------- | -------- | ---- |
 | azapi_data_response_export_values | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/a...](https://azure.github.io/Azure-Verified-Modules/specs/tf/azapi/#response_export_values-required) |
-| azapi_replace_triggers_refs | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/a...](https://azure.github.io/Azure-Verified-Modules/specs/tf/azapi/#replace_triggers_refs) |
+| azapi_replace_triggers_refs | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/spec/TFFR5/](https://azure.github.io/Azure-Verified-Modules/spec/TFFR5/) |
 | azapi_resource_tag | true | ERROR | [https://aka.ms/avm/spec/TFFR9](https://aka.ms/avm/spec/TFFR9) |
 | azapi_response_export_values | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/a...](https://azure.github.io/Azure-Verified-Modules/specs/tf/azapi/#response_export_values-required) |
 | customer_managed_key | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#customer-managed-keys) |

--- a/RULES.md
+++ b/RULES.md
@@ -5,7 +5,7 @@ This document lists all rules currently registered in this ruleset. AVM rules ar
 | Name | Enabled | Severity | Link |
 | ---- | ------- | -------- | ---- |
 | azapi_data_response_export_values | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/a...](https://azure.github.io/Azure-Verified-Modules/specs/tf/azapi/#response_export_values-required) |
-| azapi_replace_triggers_refs | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/a...](https://azure.github.io/Azure-Verified-Modules/specs/tf/azapi/#replace_triggers_refs) |
+| azapi_replace_triggers_refs | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/spec/TFFR5/](https://azure.github.io/Azure-Verified-Modules/spec/TFFR5/) |
 | azapi_resource_tag | true | ERROR | [https://aka.ms/avm/spec/TFFR9](https://aka.ms/avm/spec/TFFR9) |
 | azapi_response_export_values | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/a...](https://azure.github.io/Azure-Verified-Modules/specs/tf/azapi/#response_export_values-required) |
 | customer_managed_key | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#customer-managed-keys) |

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/hcl/v2 v2.24.0
+	github.com/jmespath/go-jmespath v0.4.0
 	github.com/prashantv/gostub v1.1.0
 	github.com/spf13/afero v1.15.0
 	github.com/stretchr/testify v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,10 @@ github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -73,6 +77,7 @@ github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTS
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
@@ -151,5 +156,7 @@ google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/integration/azapi-required-interfaces-child/child/main.tf
+++ b/integration/azapi-required-interfaces-child/child/main.tf
@@ -3,7 +3,6 @@ resource "azapi_resource" "example" {
   name                   = "example"
   parent_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example"
   response_export_values = []
-  replace_triggers_refs  = []
 }
 
 variable "resource_types" {

--- a/integration/azapi-required-interfaces-incorrect/main.tf
+++ b/integration/azapi-required-interfaces-incorrect/main.tf
@@ -3,7 +3,6 @@ resource "azapi_resource" "example" {
   name                   = "example"
   parent_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example"
   response_export_values = []
-  replace_triggers_refs  = []
 }
 
 output "resource_id" {

--- a/integration/azapi-required-interfaces/main.tf
+++ b/integration/azapi-required-interfaces/main.tf
@@ -3,7 +3,6 @@ resource "azapi_resource" "example" {
   name                   = "example"
   parent_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example"
   response_export_values = []
-  replace_triggers_refs  = []
 }
 
 variable "resource_types" {

--- a/rules/azapi_replace_triggers_refs.go
+++ b/rules/azapi_replace_triggers_refs.go
@@ -1,0 +1,316 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/jmespath/go-jmespath"
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+var _ tflint.Rule = new(AzapiReplaceTriggersRefsRule)
+
+// AzapiReplaceTriggersRefsRule validates replacement paths when they are declared.
+type AzapiReplaceTriggersRefsRule struct {
+	tflint.DefaultRule
+}
+
+// NewAzapiReplaceTriggersRefsRule returns an AzAPI replacement-trigger rule.
+func NewAzapiReplaceTriggersRefsRule() *AzapiReplaceTriggersRefsRule {
+	return new(AzapiReplaceTriggersRefsRule)
+}
+
+func (r *AzapiReplaceTriggersRefsRule) Name() string {
+	return "azapi_replace_triggers_refs"
+}
+
+func (r *AzapiReplaceTriggersRefsRule) Link() string {
+	return "https://azure.github.io/Azure-Verified-Modules/spec/TFFR5/"
+}
+
+func (r *AzapiReplaceTriggersRefsRule) Enabled() bool {
+	return true
+}
+
+func (r *AzapiReplaceTriggersRefsRule) Severity() tflint.Severity {
+	return tflint.ERROR
+}
+
+func (r *AzapiReplaceTriggersRefsRule) Check(runner tflint.Runner) error {
+	modulePath, err := runner.GetModulePath()
+	if err != nil {
+		return err
+	}
+	if !modulePath.IsRoot() {
+		return nil
+	}
+
+	content, err := runner.GetModuleContent(azapiReplaceTriggersBodySchema, &tflint.GetModuleContentOption{
+		ExpandMode: tflint.ExpandModeNone,
+	})
+	if err != nil {
+		return err
+	}
+
+	var errs error
+	for _, block := range content.Blocks {
+		if len(block.Labels) != 2 || !replaceTriggersResourceTypes[block.Labels[0]] {
+			continue
+		}
+		attribute, exists := block.Body.Attributes["replace_triggers_refs"]
+		if !exists {
+			continue
+		}
+
+		paths, ok := staticStringList(attribute.Expr)
+		if !ok {
+			if err := runner.EmitIssue(
+				r,
+				"`replace_triggers_refs` must be a statically known list of JMESPath expressions",
+				attribute.Range,
+			); err != nil {
+				errs = multierror.Append(errs, err)
+			}
+			continue
+		}
+		if len(paths) == 0 {
+			if err := runner.EmitIssue(
+				r,
+				"omit `replace_triggers_refs` when no body paths require replacement",
+				attribute.Range,
+			); err != nil {
+				errs = multierror.Append(errs, err)
+			}
+			continue
+		}
+
+		compiled := make(map[string]*jmespath.JMESPath, len(paths))
+		seen := make(map[string]struct{}, len(paths))
+		for _, path := range paths {
+			normalized := strings.TrimSpace(path)
+			switch {
+			case normalized == "":
+				errs = appendTriggerIssue(errs, runner, r, "replacement paths must not be blank", attribute.Range)
+				continue
+			case normalized != path:
+				errs = appendTriggerIssue(errs, runner, r, fmt.Sprintf("replacement path %q must not contain surrounding whitespace", path), attribute.Range)
+				continue
+			case normalized == "name" || normalized == "location":
+				errs = appendTriggerIssue(errs, runner, r, fmt.Sprintf("replacement path %q is redundant because AzAPI already replaces resources when it changes", normalized), attribute.Range)
+				continue
+			}
+			if _, duplicate := seen[normalized]; duplicate {
+				errs = appendTriggerIssue(errs, runner, r, fmt.Sprintf("replacement path %q is duplicated", normalized), attribute.Range)
+				continue
+			}
+			seen[normalized] = struct{}{}
+
+			expression, err := jmespath.Compile(normalized)
+			if err != nil {
+				errs = appendTriggerIssue(errs, runner, r, fmt.Sprintf("replacement path %q is not valid JMESPath: %v", normalized, err), attribute.Range)
+				continue
+			}
+			compiled[normalized] = expression
+		}
+
+		if len(compiled) == 0 {
+			continue
+		}
+		var body any = map[string]any{}
+		if bodyAttribute, hasBody := block.Body.Attributes["body"]; hasBody {
+			var known bool
+			body, known = staticJSONValue(bodyAttribute.Expr)
+			if !known {
+				continue
+			}
+		}
+		for path, expression := range compiled {
+			result, err := expression.Search(body)
+			if err != nil {
+				errs = appendTriggerIssue(
+					errs,
+					runner,
+					r,
+					fmt.Sprintf("replacement path %q cannot be evaluated against the static resource body: %v", path, err),
+					attribute.Range,
+				)
+				continue
+			}
+			projectionChecked, projectionResolved := simpleProjectionPathResolves(path, body)
+			if (projectionChecked && !projectionResolved) ||
+				(!projectionChecked && result == nil && !simpleObjectPathExists(path, body)) {
+				errs = appendTriggerIssue(
+					errs,
+					runner,
+					r,
+					fmt.Sprintf("replacement path %q does not resolve against the static resource body", path),
+					attribute.Range,
+				)
+			}
+		}
+	}
+	return errs
+}
+
+var replaceTriggersResourceTypes = map[string]bool{
+	"azapi_resource":            true,
+	"azapi_data_plane_resource": true,
+}
+
+var azapiReplaceTriggersBodySchema = &hclext.BodySchema{
+	Blocks: []hclext.BlockSchema{
+		{
+			Type:       "resource",
+			LabelNames: []string{"type", "name"},
+			Body: &hclext.BodySchema{
+				Attributes: []hclext.AttributeSchema{
+					{Name: "body"},
+					{Name: "replace_triggers_refs"},
+				},
+			},
+		},
+	},
+}
+
+func staticStringList(expression hcl.Expression) ([]string, bool) {
+	value, diagnostics := expression.Value(nil)
+	valueType := value.Type()
+	if diagnostics.HasErrors() ||
+		value.IsNull() ||
+		!value.IsKnown() ||
+		(!valueType.IsTupleType() && !valueType.IsListType() && !valueType.IsSetType()) {
+		return nil, false
+	}
+
+	values := make([]string, 0, value.LengthInt())
+	iterator := value.ElementIterator()
+	for iterator.Next() {
+		_, item := iterator.Element()
+		if item.IsNull() || !item.IsKnown() || item.Type() != cty.String {
+			return nil, false
+		}
+		values = append(values, item.AsString())
+	}
+	return values, true
+}
+
+func staticJSONValue(expression hcl.Expression) (any, bool) {
+	value, diagnostics := expression.Value(nil)
+	if diagnostics.HasErrors() || !value.IsKnown() {
+		return nil, false
+	}
+	if value.IsNull() {
+		return map[string]any{}, true
+	}
+	data, err := ctyjson.Marshal(value, value.Type())
+	if err != nil {
+		return nil, false
+	}
+	var decoded any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return nil, false
+	}
+	return decoded, true
+}
+
+func simpleObjectPathExists(path string, value any) bool {
+	current := value
+	for _, segment := range strings.Split(path, ".") {
+		if !validSimpleIdentifier(segment) {
+			return false
+		}
+		object, ok := current.(map[string]any)
+		if !ok {
+			return false
+		}
+		current, ok = object[segment]
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func simpleProjectionPathResolves(path string, value any) (bool, bool) {
+	if !strings.Contains(path, "[]") {
+		return false, false
+	}
+	segments := strings.Split(path, ".")
+	return walkSimpleProjectionPath(segments, value)
+}
+
+func walkSimpleProjectionPath(segments []string, value any) (bool, bool) {
+	if len(segments) == 0 {
+		return true, true
+	}
+	segment := segments[0]
+	if strings.HasSuffix(segment, "[]") {
+		name := strings.TrimSuffix(segment, "[]")
+		if !validSimpleIdentifier(name) {
+			return false, false
+		}
+		object, ok := value.(map[string]any)
+		if !ok {
+			return true, false
+		}
+		child, exists := object[name]
+		if !exists {
+			return true, false
+		}
+		items, ok := child.([]any)
+		if !ok {
+			return true, false
+		}
+		for _, item := range items {
+			checked, resolved := walkSimpleProjectionPath(segments[1:], item)
+			if !checked {
+				return false, false
+			}
+			if !resolved {
+				return true, false
+			}
+		}
+		return true, true
+	}
+	if !validSimpleIdentifier(segment) {
+		return false, false
+	}
+	object, ok := value.(map[string]any)
+	if !ok {
+		return true, false
+	}
+	child, exists := object[segment]
+	if !exists {
+		return true, false
+	}
+	return walkSimpleProjectionPath(segments[1:], child)
+}
+
+func validSimpleIdentifier(identifier string) bool {
+	if identifier == "" {
+		return false
+	}
+	for index, character := range identifier {
+		if (character >= 'a' && character <= 'z') ||
+			(character >= 'A' && character <= 'Z') ||
+			character == '_' ||
+			(index > 0 && character >= '0' && character <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func appendTriggerIssue(errs error, runner tflint.Runner, rule tflint.Rule, message string, sourceRange hcl.Range) error {
+	if err := runner.EmitIssue(rule, message, sourceRange); err != nil {
+		return multierror.Append(errs, err)
+	}
+	return errs
+}

--- a/rules/azapi_replace_triggers_refs_test.go
+++ b/rules/azapi_replace_triggers_refs_test.go
@@ -1,0 +1,216 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/jmespath/go-jmespath"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func TestAzapiReplaceTriggersRefsRule(t *testing.T) {
+	tests := []struct {
+		name          string
+		resourceType  string
+		body          string
+		triggers      string
+		expectedIssue string
+	}{
+		{
+			name:         "omitted",
+			resourceType: "azapi_resource",
+			body:         `{ properties = { sku = { name = "Standard" } } }`,
+		},
+		{
+			name:          "empty",
+			resourceType:  "azapi_resource",
+			body:          `{ properties = {} }`,
+			triggers:      "[]",
+			expectedIssue: "omit `replace_triggers_refs`",
+		},
+		{
+			name:         "valid static path",
+			resourceType: "azapi_resource",
+			body:         `{ properties = { sku = { name = "Standard" } } }`,
+			triggers:     `["properties.sku.name"]`,
+		},
+		{
+			name:         "valid data plane path",
+			resourceType: "azapi_data_plane_resource",
+			body:         `{ properties = { enabled = true } }`,
+			triggers:     `["properties.enabled"]`,
+		},
+		{
+			name:          "blank path",
+			resourceType:  "azapi_resource",
+			body:          `{ properties = {} }`,
+			triggers:      `[""]`,
+			expectedIssue: "must not be blank",
+		},
+		{
+			name:          "surrounding whitespace",
+			resourceType:  "azapi_resource",
+			body:          `{ properties = { sku = "Standard" } }`,
+			triggers:      `[" properties.sku"]`,
+			expectedIssue: "must not contain surrounding whitespace",
+		},
+		{
+			name:          "duplicate path",
+			resourceType:  "azapi_resource",
+			body:          `{ properties = { sku = "Standard" } }`,
+			triggers:      `["properties.sku", "properties.sku"]`,
+			expectedIssue: "is duplicated",
+		},
+		{
+			name:          "name is redundant",
+			resourceType:  "azapi_resource",
+			body:          `{ properties = {} }`,
+			triggers:      `["name"]`,
+			expectedIssue: "is redundant",
+		},
+		{
+			name:          "location is redundant",
+			resourceType:  "azapi_resource",
+			body:          `{ properties = {} }`,
+			triggers:      `["location"]`,
+			expectedIssue: "is redundant",
+		},
+		{
+			name:          "invalid JMESPath",
+			resourceType:  "azapi_resource",
+			body:          `{ properties = {} }`,
+			triggers:      `["properties.["]`,
+			expectedIssue: "is not valid JMESPath",
+		},
+		{
+			name:          "missing static path",
+			resourceType:  "azapi_resource",
+			body:          `{ properties = { sku = "Standard" } }`,
+			triggers:      `["properties.kind"]`,
+			expectedIssue: "does not resolve against the static resource body",
+		},
+		{
+			name:          "missing projected field",
+			resourceType:  "azapi_resource",
+			body:          `{ properties = { items = [{ existing = true }] } }`,
+			triggers:      `["properties.items[].missing"]`,
+			expectedIssue: "does not resolve against the static resource body",
+		},
+		{
+			name:         "projection over empty collection is valid",
+			resourceType: "azapi_resource",
+			body:         `{ properties = { items = [] } }`,
+			triggers:     `["properties.items[].name"]`,
+		},
+		{
+			name:          "omitted body cannot resolve declared path",
+			resourceType:  "azapi_resource",
+			triggers:      `["properties.sku"]`,
+			expectedIssue: "does not resolve against the static resource body",
+		},
+		{
+			name:          "explicit null body cannot resolve declared path",
+			resourceType:  "azapi_resource",
+			body:          `null`,
+			triggers:      `["properties.sku"]`,
+			expectedIssue: "does not resolve against the static resource body",
+		},
+		{
+			name:          "JMESPath type error becomes issue",
+			resourceType:  "azapi_resource",
+			body:          `{ properties = { sku = "Standard" } }`,
+			triggers:      `["sort(properties.sku)"]`,
+			expectedIssue: "cannot be evaluated against the static resource body",
+		},
+		{
+			name:          "JMESPath null type error becomes issue",
+			resourceType:  "azapi_resource",
+			body:          `{ properties = { sku = null } }`,
+			triggers:      `["length(properties.sku)"]`,
+			expectedIssue: "cannot be evaluated against the static resource body",
+		},
+		{
+			name:         "static null path resolves",
+			resourceType: "azapi_resource",
+			body:         `{ properties = { sku = null } }`,
+			triggers:     `["properties.sku"]`,
+		},
+		{
+			name:         "dynamic body skips resolution",
+			resourceType: "azapi_resource",
+			body:         `var.body`,
+			triggers:     `["properties.sku"]`,
+		},
+		{
+			name:          "dynamic trigger list is rejected",
+			resourceType:  "azapi_resource",
+			body:          `{ properties = {} }`,
+			triggers:      `var.replace_triggers_refs`,
+			expectedIssue: "must be a statically known list",
+		},
+		{
+			name:          "object trigger value is rejected",
+			resourceType:  "azapi_resource",
+			body:          `{ properties = {} }`,
+			triggers:      `{ path = "properties.sku" }`,
+			expectedIssue: "must be a statically known list",
+		},
+		{
+			name:         "unrelated resource is ignored",
+			resourceType: "random_string",
+			body:         `{}`,
+			triggers:     `[]`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := helper.TestRunner(t, map[string]string{
+				"main.tf": replaceTriggersResource(test.resourceType, test.body, test.triggers),
+			})
+			rule := NewAzapiReplaceTriggersRefsRule()
+			require.NoError(t, rule.Check(runner))
+			if test.expectedIssue == "" {
+				assert.Empty(t, runner.Issues)
+				return
+			}
+			require.Len(t, runner.Issues, 1)
+			assert.Contains(t, runner.Issues[0].Message, test.expectedIssue)
+		})
+	}
+}
+
+func TestStaticJSONValue_preservesNullProperties(t *testing.T) {
+	expression, diagnostics := hclsyntax.ParseExpression(
+		[]byte(`{ properties = { sku = null } }`),
+		"test.tf",
+		hcl.InitialPos,
+	)
+	require.False(t, diagnostics.HasErrors())
+
+	value, known := staticJSONValue(expression)
+	require.True(t, known)
+	result, err := jmespath.Search("properties.sku", value)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+	assert.True(t, simpleObjectPathExists("properties.sku", value))
+	assert.False(t, simpleObjectPathExists("properties.missing", value))
+}
+
+func replaceTriggersResource(resourceType, body, triggers string) string {
+	bodyAttribute := ""
+	if body != "" {
+		bodyAttribute = "\n  body = " + body
+	}
+	triggerAttribute := ""
+	if triggers != "" {
+		triggerAttribute = "\n  replace_triggers_refs = " + triggers
+	}
+	return `resource "` + resourceType + `" "this" {` + bodyAttribute + triggerAttribute + `
+}`
+}

--- a/rules/rule_register.go
+++ b/rules/rule_register.go
@@ -15,6 +15,7 @@ var Rules = func() []tflint.Rule {
 		[]tflint.Rule{
 			NewTerraformTfFileRule(),
 			NewAzapiResourceTagRule(),
+			NewAzapiReplaceTriggersRefsRule(),
 			NewModuleSourceRule(),
 			NewNoDoubleQuotesInIgnoreChangesRule(),
 			NewDisallowedProviderRule("azurerm", "hashicorp/azurerm"),
@@ -41,15 +42,6 @@ var Rules = func() []tflint.Rule {
 				"[]",
 				tflint.ERROR,
 				DisallowWildcardList("response_export_values"),
-			),
-			NewRequiredAttributeRule(
-				"azapi_replace_triggers_refs",
-				"https://azure.github.io/Azure-Verified-Modules/specs/tf/azapi/#replace_triggers_refs",
-				"resource",
-				[]string{"azapi_resource"},
-				"replace_triggers_refs",
-				"[]",
-				tflint.ERROR,
 			),
 		},
 		interfaces.Rules,


### PR DESCRIPTION
## Summary
- allow `replace_triggers_refs` to be omitted when no body path requires replacement
- reject explicit empty or dynamic trigger lists
- validate nonblank, unique JMESPath expressions
- reject redundant `name` and `location` triggers
- verify paths against statically evaluable bodies, including projected fields and null-valued properties
- apply the rule to both `azapi_resource` and `azapi_data_plane_resource`
- update integration fixtures and link the rule directly to TFFR5

The rule validates declared paths but does not claim semantic completeness: authors remain responsible for identifying API properties whose changes require replacement.

## Related documentation
- [Public docs PR #2881](https://github.com/Azure/Azure-Verified-Modules/pull/2881) updates TFFR5 and the public TFLint rule guide.

## Assumed release
This change targets ruleset `v0.21.0`. A coordinated Avm.Authoring PR will pin that version and remains blocked until the attested release exists.

## Validation
- `go test ./...`
- `go build ./...`
- `go vet ./...`
- `go mod verify`
- `golangci-lint run ./...`
- freshly built local plugin integration tests
- generated rules documentation consistency