### PR TITLE
feat: support AVM resource tag overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ workflow regenerates it from `azure-rest-api-specs` through
 `bicep-types-az`, validates it, and opens or updates a deterministic PR only
 when the data changes.
 
+For writable resource types, the rule requires a consumer-settable `tags`
+argument but permits any Terraform expression so modules can implement the
+standard module-wide fallback and per-resource override contract. Resource
+types with read-only or unsupported tags must omit the argument.
+
+When a module exposes per-resource or submodule tag overrides, the
+`avm_interface_resource_tags` rule validates the typed recursive
+`resource_tags` interface. The interface separates resource block labels under
+`resources` from child module labels under `modules`; omitted or null resource
+maps inherit `var.tags`, while supplied maps replace it without merging, and
+`{}` deliberately removes all tags.
+
 ## Requirements
 
 - TFLint v0.62+
@@ -66,6 +78,7 @@ The supported severity values are `error`, `warning`, and `notice`. Any other va
 | avm_interface_private_endpoints | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#private-endpoints) |
 | avm_interface_private_endpoints_deprecated | true | NOTICE | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#private-endpoints) |
 | avm_interface_private_endpoints_manage_dns_zone_group | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/includes/i...](https://azure.github.io/Azure-Verified-Modules/includes/interfaces/tf/int.pe.schema.tf) |
+| avm_interface_resource_tags | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#tags) |
 | avm_interface_resource_types | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/spec/TFFR6/](https://azure.github.io/Azure-Verified-Modules/spec/TFFR6/) |
 | avm_interface_retry | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/spec/TFFR7/](https://azure.github.io/Azure-Verified-Modules/spec/TFFR7/) |
 | avm_interface_role_assignments | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#role-assignments) |

--- a/RULES.md
+++ b/RULES.md
@@ -18,6 +18,7 @@ This document lists all rules currently registered in this ruleset. AVM rules ar
 | avm_interface_private_endpoints | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#private-endpoints) |
 | avm_interface_private_endpoints_deprecated | true | NOTICE | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#private-endpoints) |
 | avm_interface_private_endpoints_manage_dns_zone_group | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/includes/i...](https://azure.github.io/Azure-Verified-Modules/includes/interfaces/tf/int.pe.schema.tf) |
+| avm_interface_resource_tags | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#tags) |
 | avm_interface_resource_types | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/spec/TFFR6/](https://azure.github.io/Azure-Verified-Modules/spec/TFFR6/) |
 | avm_interface_retry | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/spec/TFFR7/](https://azure.github.io/Azure-Verified-Modules/spec/TFFR7/) |
 | avm_interface_role_assignments | true | ERROR | [https://azure.github.io/Azure-Verified-Modules/specs/tf/i...](https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#role-assignments) |

--- a/interfaces/avm_interface_resource_tags_test.go
+++ b/interfaces/avm_interface_resource_tags_test.go
@@ -1,0 +1,202 @@
+package interfaces_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+const validResourceTags = `variable "resource_tags" {
+  type = object({
+    resources = optional(object({
+      this      = optional(map(string))
+      secondary = optional(map(string))
+    }))
+    modules = optional(object({
+      child = optional(object({
+        resources = optional(object({
+          this = optional(map(string))
+        }))
+      }))
+    }))
+  })
+  default = null
+}`
+
+func TestResourceTagsAcceptsCanonicalRecursiveShapes(t *testing.T) {
+	rule := requiredInterfaceRule(t, "resource_tags")
+	cases := map[string]string{
+		"resources and modules": validResourceTags,
+		"resources only": `variable "resource_tags" {
+  type = object({
+    resources = optional(object({
+      this = optional(map(string))
+    }))
+  })
+  default = null
+}`,
+		"modules only": `variable "resource_tags" {
+  type = object({
+    modules = optional(object({
+      child = optional(object({
+        resources = optional(object({
+          this = optional(map(string))
+        }))
+      }))
+    }))
+  })
+  default = null
+}`,
+		"explicit nullable true": strings.Replace(
+			validResourceTags,
+			"  default = null\n",
+			"  default  = null\n  nullable = true\n",
+			1,
+		),
+	}
+
+	for name, content := range cases {
+		content := content
+		t.Run(name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"variables.tf": content})
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			helper.AssertIssues(t, helper.Issues{}, runner.Issues)
+		})
+	}
+}
+
+func TestResourceTagsIsOptional(t *testing.T) {
+	rule := requiredInterfaceRule(t, "resource_tags")
+	runner := helper.TestRunner(t, map[string]string{
+		"variables.tf": `variable "tags" {
+  type    = map(string)
+  default = null
+}`,
+	})
+
+	if err := rule.Check(runner); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	helper.AssertIssues(t, helper.Issues{}, runner.Issues)
+}
+
+func TestResourceTagsRejectsMalformedRecursiveShapes(t *testing.T) {
+	rule := requiredInterfaceRule(t, "resource_tags")
+	expectation := "must use optional `resources` and `modules` namespaces with optional `map(string)` resource leaves and recursive module objects"
+	cases := map[string]string{
+		"top level map": `variable "resource_tags" {
+  type    = map(map(string))
+  default = null
+}`,
+		"unknown namespace": strings.Replace(validResourceTags, "    modules = optional(object({", "    children = optional(object({", 1),
+		"flat resource leaf": strings.Replace(
+			validResourceTags,
+			`    resources = optional(object({
+      this      = optional(map(string))
+      secondary = optional(map(string))
+    }))`,
+			`    this = optional(map(string))`,
+			1,
+		),
+		"required resources namespace": `variable "resource_tags" {
+  type = object({
+    resources = object({
+      this = optional(map(string))
+    })
+  })
+  default = null
+}`,
+		"resources namespace default": strings.Replace(validResourceTags, "    }))\n    modules", "    }), {})\n    modules", 1),
+		"required resource leaf":      strings.Replace(validResourceTags, "this      = optional(map(string))", "this      = map(string)", 1),
+		"wrong resource leaf type":    strings.Replace(validResourceTags, "secondary = optional(map(string))", "secondary = optional(list(string))", 1),
+		"resource leaf default":       strings.Replace(validResourceTags, "this      = optional(map(string))", "this      = optional(map(string), {})", 1),
+		"required module": `variable "resource_tags" {
+  type = object({
+    modules = optional(object({
+      child = object({
+        resources = optional(object({
+          this = optional(map(string))
+        }))
+      })
+    }))
+  })
+  default = null
+}`,
+		"module default": strings.Replace(validResourceTags, "      }))\n    }))", "      }), {})\n    }))", 1),
+		"flattened child shape": strings.Replace(
+			validResourceTags,
+			`      child = optional(object({
+        resources = optional(object({
+          this = optional(map(string))
+        }))
+      }))`,
+			`      child = optional(object({
+        this = optional(map(string))
+      }))`,
+			1,
+		),
+		"empty resources namespace": strings.Replace(
+			validResourceTags,
+			`    resources = optional(object({
+      this      = optional(map(string))
+      secondary = optional(map(string))
+    }))`,
+			`    resources = optional(object({}))`,
+			1,
+		),
+		"empty top level object": `variable "resource_tags" {
+  type    = object({})
+  default = null
+}`,
+	}
+
+	for name, content := range cases {
+		content := content
+		t.Run(name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"variables.tf": content})
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			helper.AssertIssuesWithoutRange(
+				t,
+				expectedVariableAttributeIssue(rule, "type", expectation, hcl.Range{}),
+				runner.Issues,
+			)
+		})
+	}
+}
+
+func TestResourceTagsRejectsDefaultAndNullability(t *testing.T) {
+	rule := requiredInterfaceRule(t, "resource_tags")
+	cases := []struct {
+		name        string
+		content     string
+		attribute   string
+		expectation string
+	}{
+		{
+			name:        "missing default",
+			content:     strings.Replace(validResourceTags, "  default = null\n", "", 1),
+			attribute:   "default",
+			expectation: "must be `null`",
+		},
+		{
+			name:        "empty object default",
+			content:     strings.Replace(validResourceTags, "default = null", "default = {}", 1),
+			attribute:   "default",
+			expectation: "must be `null`",
+		},
+		{
+			name:        "nullable false",
+			content:     strings.Replace(validResourceTags, "  default = null\n", "  default  = null\n  nullable = false\n", 1),
+			attribute:   "nullable",
+			expectation: "must permit `null`",
+		},
+	}
+
+	runMalformedVariableCases(t, rule, cases)
+}

--- a/interfaces/azapi_required_interfaces.go
+++ b/interfaces/azapi_required_interfaces.go
@@ -13,6 +13,7 @@ const (
 	retryTimeoutsRuleLink      = "https://azure.github.io/Azure-Verified-Modules/spec/TFFR7/"
 	ignoreBodyChangesRuleLink  = "https://azure.github.io/Azure-Verified-Modules/spec/TFFR8/"
 	privateEndpointsSchemaLink = "https://azure.github.io/Azure-Verified-Modules/includes/interfaces/tf/int.pe.schema.tf"
+	resourceTagsRuleLink       = "https://azure.github.io/Azure-Verified-Modules/specs/tf/interfaces/#tags"
 )
 
 const retryTypeString = `object({
@@ -103,6 +104,21 @@ var requiredInterfaceRules = []tflint.Rule{
 		}),
 	),
 	newRequiredVariableRule(
+		"avm_interface_resource_tags",
+		"resource_tags",
+		resourceTagsRuleLink,
+		"when per-resource or submodule tag overrides are exposed",
+		appliesWhenVariableDeclared("resource_tags"),
+		validateVariableShape(variableShape{
+			typeDescription:     "must use optional `resources` and `modules` namespaces with optional `map(string)` resource leaves and recursive module objects",
+			defaultDescription:  "must be `null`",
+			nullableDescription: "must permit `null`",
+			validateType:        validateResourceTagsType,
+			validateDefault:     nullDefault,
+			nullable:            nullableMayBeTrue,
+		}),
+	),
+	newRequiredVariableRule(
 		"avm_interface_private_endpoints_manage_dns_zone_group",
 		"private_endpoints_manage_dns_zone_group",
 		privateEndpointsSchemaLink,
@@ -139,6 +155,92 @@ func validateIgnoreBodyChangesType(got varcheck.TypeConstraintWithDefaults) bool
 
 	directLeaves, ok := validateRecursiveObject(got.Type, got.Default, 0, ignoreBodyChangesLeaf)
 	return ok && directLeaves > 0
+}
+
+func validateResourceTagsType(got varcheck.TypeConstraintWithDefaults) bool {
+	resourceLeaves, ok := validateResourceTagsObject(got.Type, got.Default)
+	return ok && resourceLeaves > 0
+}
+
+func validateResourceTagsObject(objectType cty.Type, defaults *typeexpr.Defaults) (int, bool) {
+	if !objectType.IsObjectType() {
+		return 0, false
+	}
+
+	attributes := objectType.AttributeTypes()
+	if len(attributes) == 0 || len(attributes) > 2 {
+		return 0, false
+	}
+
+	resourceLeaves := 0
+	for name, attributeType := range attributes {
+		if !objectType.AttributeOptional(name) {
+			return 0, false
+		}
+		if _, hasDefault := defaultsValue(defaults, name); hasDefault {
+			return 0, false
+		}
+
+		var (
+			leaves int
+			ok     bool
+		)
+		switch name {
+		case "resources":
+			leaves, ok = validateResourceTagsResources(attributeType, defaultsChild(defaults, name))
+		case "modules":
+			leaves, ok = validateResourceTagsModules(attributeType, defaultsChild(defaults, name))
+		default:
+			return 0, false
+		}
+		if !ok {
+			return 0, false
+		}
+		resourceLeaves += leaves
+	}
+
+	return resourceLeaves, true
+}
+
+func validateResourceTagsResources(objectType cty.Type, defaults *typeexpr.Defaults) (int, bool) {
+	if !objectType.IsObjectType() || len(objectType.AttributeTypes()) == 0 {
+		return 0, false
+	}
+
+	for name, attributeType := range objectType.AttributeTypes() {
+		if !objectType.AttributeOptional(name) || !attributeType.Equals(cty.Map(cty.String)) {
+			return 0, false
+		}
+		if _, hasDefault := defaultsValue(defaults, name); hasDefault {
+			return 0, false
+		}
+	}
+
+	return len(objectType.AttributeTypes()), true
+}
+
+func validateResourceTagsModules(objectType cty.Type, defaults *typeexpr.Defaults) (int, bool) {
+	if !objectType.IsObjectType() || len(objectType.AttributeTypes()) == 0 {
+		return 0, false
+	}
+
+	resourceLeaves := 0
+	for name, attributeType := range objectType.AttributeTypes() {
+		if !objectType.AttributeOptional(name) || !attributeType.IsObjectType() {
+			return 0, false
+		}
+		if _, hasDefault := defaultsValue(defaults, name); hasDefault {
+			return 0, false
+		}
+
+		leaves, ok := validateResourceTagsObject(attributeType, defaultsChild(defaults, name))
+		if !ok {
+			return 0, false
+		}
+		resourceLeaves += leaves
+	}
+
+	return resourceLeaves, true
 }
 
 type recursiveLeafValidator func(cty.Type, *typeexpr.Defaults, string, int) bool
@@ -236,6 +338,10 @@ func validateFlatOptionalObject(got varcheck.TypeConstraintWithDefaults, expecte
 
 func emptyObjectDefault(got cty.Value, _ varcheck.TypeConstraintWithDefaults) bool {
 	return got.RawEquals(cty.EmptyObjectVal)
+}
+
+func nullDefault(got cty.Value, _ varcheck.TypeConstraintWithDefaults) bool {
+	return got.IsNull()
 }
 
 func nullableObjectDefault(got cty.Value, typeConstraint varcheck.TypeConstraintWithDefaults) bool {

--- a/rules/avm_azapi_resource_tags_required.go
+++ b/rules/avm_azapi_resource_tags_required.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/Azure/tflint-ruleset-avm/internal/tagcapability"
-	"github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/logger"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
@@ -86,18 +85,8 @@ func (r *AzapiResourceTagRule) Check(runner tflint.Runner) error {
 			if !hasTags {
 				if err := runner.EmitIssue(
 					r,
-					fmt.Sprintf("AzAPI resource type `%s` supports tags and must set `tags = var.tags`", resourceType),
+					fmt.Sprintf("AzAPI resource type `%s` supports tags and must set `tags`", resourceType),
 					block.DefRange,
-				); err != nil {
-					return err
-				}
-				continue
-			}
-			if !isStandardTagsExpression(tagsAttribute.Expr) {
-				if err := runner.EmitIssue(
-					r,
-					"AzAPI resources that support tags must set exactly `tags = var.tags`",
-					tagsAttribute.Range,
 				); err != nil {
 					return err
 				}
@@ -132,16 +121,6 @@ var azapiResourceTagBodySchema = &hclext.BodySchema{
 			},
 		},
 	},
-}
-
-func isStandardTagsExpression(expression hcl.Expression) bool {
-	traversal, diags := hcl.AbsTraversalForExpr(expression)
-	if diags.HasErrors() || len(traversal) != 2 {
-		return false
-	}
-	root, rootOK := traversal[0].(hcl.TraverseRoot)
-	attribute, attributeOK := traversal[1].(hcl.TraverseAttr)
-	return rootOK && attributeOK && root.Name == "var" && attribute.Name == "tags"
 }
 
 func knownCapabilityLookupError(err error) bool {

--- a/rules/avm_azapi_resource_tags_required_test.go
+++ b/rules/avm_azapi_resource_tags_required_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"github.com/Azure/tflint-ruleset-avm/internal/tagcapability"
-	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
@@ -30,14 +28,19 @@ func TestAzapiResourceTagRule(t *testing.T) {
 			name:          "supported resource is missing tags",
 			content:       azapiResource(`Microsoft.Resources/resourceGroups@2021-04-01`, ""),
 			status:        tagcapability.StatusWritable,
-			expectedIssue: "must set `tags = var.tags`",
+			expectedIssue: "must set `tags`",
 		},
 		{
-			name: "supported resource transforms tags",
+			name: "supported resource uses per-resource tags",
 			content: azapiResource(`Microsoft.Resources/resourceGroups@2021-04-01`, `
-  tags = merge(var.tags, { environment = "test" })`),
-			status:        tagcapability.StatusWritable,
-			expectedIssue: "must set exactly `tags = var.tags`",
+  tags = try(var.resource_tags.resources.this, null) != null ? var.resource_tags.resources.this : var.tags`),
+			status: tagcapability.StatusWritable,
+		},
+		{
+			name: "supported resource uses local tags expression",
+			content: azapiResource(`Microsoft.Resources/resourceGroups@2021-04-01`, `
+  tags = local.resource_tags`),
+			status: tagcapability.StatusWritable,
 		},
 		{
 			name:    "unsupported resource omits tags",
@@ -142,23 +145,6 @@ func TestAzapiResourceTagRule_embeddedSnapshot(t *testing.T) {
 
 	require.NoError(t, rule.Check(runner))
 	assert.Empty(t, runner.Issues)
-}
-
-func TestIsStandardTagsExpression(t *testing.T) {
-	tests := map[string]bool{
-		"var.tags":                          true,
-		"var.other":                         false,
-		"local.tags":                        false,
-		"merge(var.tags, local.extra_tags)": false,
-	}
-	for expression, expected := range tests {
-		t.Run(expression, func(t *testing.T) {
-			t.Parallel()
-			parsed, diags := hclsyntax.ParseExpression([]byte(expression), "test.tf", hcl.InitialPos)
-			require.False(t, diags.HasErrors())
-			assert.Equal(t, expected, isStandardTagsExpression(parsed))
-		})
-	}
 }
 
 func azapiResource(resourceType, body string) string {


### PR DESCRIPTION
## Summary
- allow writable AzAPI resources to use any consumer-settable `tags` expression while still requiring the argument
- continue rejecting `tags` on read-only and unsupported resource types from the embedded capability snapshot
- add the optional `avm_interface_resource_tags` rule for the canonical recursive `resources`/`modules` interface with `map(string)` leaves and a null default
- document the revised contract and regenerate the rule reference

## Related specification
- Canonical contract: https://github.com/Azure/Azure-Verified-Modules/pull/2900

## Validation
- `go test --count=1` for all non-integration packages
- `go build`
- `go vet`
- `golangci-lint run ./...`
- `gosec -quiet ./...`